### PR TITLE
fix(pyo3): re-export return types from native module, not options.py

### DIFF
--- a/crates/alef-backend-java/src/gen_bindings.rs
+++ b/crates/alef-backend-java/src/gen_bindings.rs
@@ -1743,9 +1743,10 @@ fn gen_java_tagged_union(package: &str, enum_def: &EnumDef) -> String {
         !variant_names.contains("Optional") && enum_def.variants.iter().any(|v| v.fields.iter().any(|f| f.optional));
     // Newtype/tuple variants (field name is a numeric index like "0") are flattened
     // into the parent JSON object using @JsonUnwrapped.
-    let needs_unwrapped = enum_def.variants.iter().any(|v| {
-        v.fields.len() == 1 && is_tuple_field_name(&v.fields[0].name)
-    });
+    let needs_unwrapped = enum_def
+        .variants
+        .iter()
+        .any(|v| v.fields.len() == 1 && is_tuple_field_name(&v.fields[0].name));
     if needs_list {
         writeln!(out, "import java.util.List;").ok();
     }

--- a/crates/alef-backend-java/tests/gen_bindings_test.rs
+++ b/crates/alef-backend-java/tests/gen_bindings_test.rs
@@ -632,10 +632,16 @@ fn test_tagged_union_newtype_variants_produce_valid_java() {
     let content = &message_file.content;
 
     // Must be a sealed interface (internally tagged)
-    assert!(content.contains("public sealed interface Message"), "should be sealed interface:\n{content}");
+    assert!(
+        content.contains("public sealed interface Message"),
+        "should be sealed interface:\n{content}"
+    );
 
     // @JsonUnwrapped must appear for each newtype variant; numeric "0" must not be used as a field name
-    assert!(content.contains("@JsonUnwrapped"), "should use @JsonUnwrapped for newtype fields:\n{content}");
+    assert!(
+        content.contains("@JsonUnwrapped"),
+        "should use @JsonUnwrapped for newtype fields:\n{content}"
+    );
     assert!(
         !content.contains("\"0\""),
         "numeric tuple index must not appear as a Java field name or @JsonProperty value:\n{content}"
@@ -646,9 +652,18 @@ fn test_tagged_union_newtype_variants_produce_valid_java() {
     );
 
     // Each variant record should declare a `value` field
-    assert!(content.contains("SystemMessage value"), "System variant should have `value` field:\n{content}");
-    assert!(content.contains("UserMessage value"), "User variant should have `value` field:\n{content}");
-    assert!(content.contains("AssistantMessage value"), "Assistant variant should have `value` field:\n{content}");
+    assert!(
+        content.contains("SystemMessage value"),
+        "System variant should have `value` field:\n{content}"
+    );
+    assert!(
+        content.contains("UserMessage value"),
+        "User variant should have `value` field:\n{content}"
+    );
+    assert!(
+        content.contains("AssistantMessage value"),
+        "Assistant variant should have `value` field:\n{content}"
+    );
 
     // Jackson annotations for the discriminator must be present
     assert!(

--- a/crates/alef-backend-magnus/tests/gen_stubs_test.rs
+++ b/crates/alef-backend-magnus/tests/gen_stubs_test.rs
@@ -793,7 +793,7 @@ fn test_multiline_doc_comment_is_valid_rbs() {
         // Must not exist as a bare (un-commented) line
         for line in content.lines() {
             let trimmed = line.trim();
-            assert!(!(trimmed == fragment), "Bare prose leaked into RBS output: {line:?}");
+            assert!(trimmed != fragment, "Bare prose leaked into RBS output: {line:?}");
         }
     }
 

--- a/crates/alef-backend-pyo3/src/gen_bindings.rs
+++ b/crates/alef-backend-pyo3/src/gen_bindings.rs
@@ -380,7 +380,7 @@ impl Backend for Pyo3Backend {
         });
 
         // 4. Generate __init__.py (re-exports)
-        let init_content = gen_init_py(api, &module_name, &api.version);
+        let init_content = gen_init_py(api, &module_name, &api.version, &config.dto);
         files.push(GeneratedFile {
             path: output_base.join("__init__.py"),
             content: init_content,
@@ -538,6 +538,15 @@ fn gen_options_py(api: &ApiSurface, _package_name: &str, dto: &DtoConfig) -> Str
 
         // Use TypedDict for return types when the output style is configured as TypedDict.
         let use_typeddict = output_style == PythonDtoStyle::TypedDict && typ.is_return_type;
+
+        // Return types are defined authoritatively by the Rust native module as #[pyclass]
+        // structs. Emitting a @dataclass with the same name creates a shadow class that breaks
+        // static analysis — Pylance reports a type mismatch because the @dataclass and the
+        // native PyO3 class are unrelated types even though they share a name.
+        // Only emit a TypedDict when explicitly configured; otherwise skip entirely.
+        if typ.is_return_type && !use_typeddict {
+            continue;
+        }
 
         if use_typeddict {
             out.push_str(&gen_typeddict(typ, &enum_names, &data_enum_names));
@@ -1307,7 +1316,7 @@ fn gen_exceptions_py(api: &ApiSurface) -> String {
 
 /// Generate __init__.py — re-exports and version.
 /// Only exports user-facing types (not internal Update types or all enums).
-fn gen_init_py(api: &ApiSurface, module_name: &str, version: &str) -> String {
+fn gen_init_py(api: &ApiSurface, module_name: &str, version: &str, dto: &DtoConfig) -> String {
     use alef_core::ir::TypeRef;
 
     let mut out = String::with_capacity(1024);
@@ -1324,12 +1333,25 @@ fn gen_init_py(api: &ApiSurface, module_name: &str, version: &str) -> String {
         .filter(|e| generators::enum_has_data_variants(e))
         .map(|e| e.name.clone())
         .collect();
+    let output_style = dto.python_output_style();
     let mut needed_enums: Vec<String> = Vec::new();
     let mut needed_data_enums: Vec<String> = Vec::new();
     let mut config_types: Vec<String> = Vec::new();
+    // Return types with is_return_type=true are defined authoritatively in the native Rust
+    // module. When not using TypedDict style (which emits a structural type in options.py),
+    // they must be re-exported from the native module — not from .options — so that the
+    // type seen by static analysis tools matches the actual runtime object returned by functions.
+    let mut native_return_types: Vec<String> = Vec::new();
     for typ in api.types.iter().filter(|typ| !typ.is_trait) {
         if typ.has_default && !typ.name.ends_with("Update") {
-            config_types.push(typ.name.clone());
+            let is_native_return = typ.is_return_type && output_style != PythonDtoStyle::TypedDict;
+            if is_native_return {
+                native_return_types.push(typ.name.clone());
+            } else {
+                config_types.push(typ.name.clone());
+            }
+            // Collect enum references regardless of whether the type is a return type or config
+            // type — some enums are shared across both categories.
             for field in &typ.fields {
                 let inner_name = match &field.ty {
                     TypeRef::Named(n) => Some(n.as_str()),
@@ -1368,9 +1390,12 @@ fn gen_init_py(api: &ApiSurface, module_name: &str, version: &str) -> String {
         imports_from_api.extend(names);
     }
 
-    // Data enums are backed by native Rust structs — import from the native module.
+    // Data enums and return types are backed by native Rust structs — import from the native module.
     needed_data_enums.sort();
     imports_from_native.extend(needed_data_enums.iter().cloned());
+    native_return_types.sort();
+    imports_from_native.extend(native_return_types.iter().cloned());
+    imports_from_native.sort();
 
     // Import plain enums and config types from options
     let mut opt_imports = needed_enums.clone();
@@ -1450,6 +1475,7 @@ fn gen_init_py(api: &ApiSurface, module_name: &str, version: &str) -> String {
     }
     all_items.extend(needed_enums);
     all_items.extend(needed_data_enums);
+    all_items.extend(native_return_types);
     all_items.extend(config_types);
     all_items.extend(exc_names);
     all_items.sort();

--- a/crates/alef-backend-pyo3/src/gen_stubs.rs
+++ b/crates/alef-backend-pyo3/src/gen_stubs.rs
@@ -327,28 +327,26 @@ fn gen_method_stub(method: &MethodDef, is_static: bool) -> String {
                 wrapped
             }
         }
+    } else if params.is_empty() {
+        format!("{}def {}(self) -> {}: ...", indent, safe_name, return_type)
     } else {
-        if params.is_empty() {
-            format!("{}def {}(self) -> {}: ...", indent, safe_name, return_type)
+        let single_line = format!(
+            "{}def {}(self, {}) -> {}: ...",
+            indent,
+            safe_name,
+            params.join(", "),
+            return_type
+        );
+        if single_line.len() <= 100 {
+            single_line
         } else {
-            let single_line = format!(
-                "{}def {}(self, {}) -> {}: ...",
-                indent,
-                safe_name,
-                params.join(", "),
-                return_type
-            );
-            if single_line.len() <= 100 {
-                single_line
-            } else {
-                let mut wrapped = format!("{}def {}(\n", indent, safe_name);
-                wrapped.push_str(&format!("{}    self,\n", indent));
-                for param in &params {
-                    wrapped.push_str(&format!("{}    {},\n", indent, param));
-                }
-                wrapped.push_str(&format!("{}) -> {}: ...", indent, return_type));
-                wrapped
+            let mut wrapped = format!("{}def {}(\n", indent, safe_name);
+            wrapped.push_str(&format!("{}    self,\n", indent));
+            for param in &params {
+                wrapped.push_str(&format!("{}    {},\n", indent, param));
             }
+            wrapped.push_str(&format!("{}) -> {}: ...", indent, return_type));
+            wrapped
         }
     }
 }

--- a/crates/alef-backend-pyo3/tests/gen_bindings_test.rs
+++ b/crates/alef-backend-pyo3/tests/gen_bindings_test.rs
@@ -1,6 +1,6 @@
 use alef_backend_pyo3::Pyo3Backend;
 use alef_core::backend::Backend;
-use alef_core::config::{AlefConfig, CrateConfig, PythonConfig};
+use alef_core::config::{AlefConfig, CrateConfig, PythonConfig, StubsConfig};
 use alef_core::ir::*;
 
 fn make_field(name: &str, ty: TypeRef, optional: bool) -> FieldDef {
@@ -1196,4 +1196,170 @@ fn test_exceptions_py_classes_without_docs_have_generated_docstrings() {
             );
         }
     }
+}
+
+/// Regression test for kreuzberg-dev/alef#1 / kreuzberg-dev/html-to-markdown#310.
+///
+/// A type with both `has_default = true` AND `is_return_type = true` (e.g. `ConversionResult`)
+/// must be re-exported in `__init__.py` from the native Rust module, NOT from `options.py`.
+/// `options.py` must NOT emit a `@dataclass` shadow class for such types; the authoritative
+/// definition lives in the native module as a `#[pyclass]` struct. The shadow class caused
+/// static analysis tools (Pylance) to report a type mismatch because the two classes are
+/// unrelated even though they share a name.
+#[test]
+fn test_return_type_exported_from_native_module_not_options() {
+    let backend = Pyo3Backend;
+
+    // ConversionResult: has_default=true (implements Default), is_return_type=true (returned by convert())
+    // ConversionOptions: has_default=true, is_return_type=false (input/config type)
+    let conversion_result = TypeDef {
+        name: "ConversionResult".to_string(),
+        rust_path: "my_lib::ConversionResult".to_string(),
+        fields: vec![
+            make_field("content", TypeRef::String, false),
+            make_field("title", TypeRef::Optional(Box::new(TypeRef::String)), true),
+        ],
+        methods: vec![],
+        is_opaque: false,
+        is_clone: true,
+        is_trait: false,
+        has_default: true,
+        has_stripped_cfg_fields: false,
+        is_return_type: true,
+        serde_rename_all: None,
+        has_serde: false,
+        doc: "Result of a conversion operation.".to_string(),
+        cfg: None,
+    };
+
+    let conversion_options = TypeDef {
+        name: "ConversionOptions".to_string(),
+        rust_path: "my_lib::ConversionOptions".to_string(),
+        fields: vec![make_field("verbose", TypeRef::Primitive(PrimitiveType::Bool), false)],
+        methods: vec![],
+        is_opaque: false,
+        is_clone: true,
+        is_trait: false,
+        has_default: true,
+        has_stripped_cfg_fields: false,
+        is_return_type: false,
+        serde_rename_all: None,
+        has_serde: false,
+        doc: "Options for conversion.".to_string(),
+        cfg: None,
+    };
+
+    let api = ApiSurface {
+        crate_name: "my_lib".to_string(),
+        version: "1.0.0".to_string(),
+        types: vec![conversion_result, conversion_options],
+        functions: vec![FunctionDef {
+            name: "convert".to_string(),
+            rust_path: "my_lib::convert".to_string(),
+            params: vec![ParamDef {
+                name: "input".to_string(),
+                ty: TypeRef::String,
+                optional: false,
+                default: None,
+                sanitized: false,
+                typed_default: None,
+                is_ref: false,
+                is_mut: false,
+                newtype_wrapper: None,
+            }],
+            return_type: TypeRef::Named("ConversionResult".to_string()),
+            is_async: false,
+            error_type: None,
+            doc: "Convert input to markdown.".to_string(),
+            cfg: None,
+            sanitized: false,
+            returns_ref: false,
+            returns_cow: false,
+            return_newtype_wrapper: None,
+        }],
+        enums: vec![],
+        errors: vec![],
+    };
+
+    let mut config = make_config();
+    config.python = Some(PythonConfig {
+        module_name: Some("_my_lib".to_string()),
+        pip_name: None,
+        async_runtime: None,
+        stubs: Some(StubsConfig {
+            output: std::path::PathBuf::from("packages/python/my_lib"),
+        }),
+        features: None,
+        serde_rename_all: None,
+    });
+
+    let files = backend
+        .generate_public_api(&api, &config)
+        .expect("generate_public_api failed");
+
+    let init_py = files
+        .iter()
+        .find(|f| f.path.ends_with("__init__.py"))
+        .expect("__init__.py not generated");
+    let options_py = files
+        .iter()
+        .find(|f| f.path.ends_with("options.py"))
+        .expect("options.py not generated");
+
+    // ConversionResult (return type) must be imported from the native module.
+    let native_import_line = init_py
+        .content
+        .lines()
+        .find(|l| l.contains("from ._my_lib import"))
+        .unwrap_or("");
+    assert!(
+        native_import_line.contains("ConversionResult"),
+        "__init__.py must import ConversionResult from the native module, got:\n{}",
+        init_py.content
+    );
+
+    // ConversionResult must NOT appear in the .options import.
+    let options_import_line = init_py
+        .content
+        .lines()
+        .find(|l| l.contains("from .options import"))
+        .unwrap_or("");
+    assert!(
+        !options_import_line.contains("ConversionResult"),
+        "__init__.py must not import ConversionResult from .options, got:\n{}",
+        init_py.content
+    );
+
+    // ConversionOptions (config/input type) must still be imported from .options.
+    assert!(
+        options_import_line.contains("ConversionOptions"),
+        "__init__.py must import ConversionOptions from .options, got:\n{}",
+        init_py.content
+    );
+
+    // Both names must appear in __all__.
+    assert!(
+        init_py.content.contains("\"ConversionResult\""),
+        "__init__.py __all__ must include ConversionResult, got:\n{}",
+        init_py.content
+    );
+    assert!(
+        init_py.content.contains("\"ConversionOptions\""),
+        "__init__.py __all__ must include ConversionOptions, got:\n{}",
+        init_py.content
+    );
+
+    // options.py must NOT define a @dataclass shadow for ConversionResult.
+    assert!(
+        !options_py.content.contains("class ConversionResult"),
+        "options.py must not define a ConversionResult shadow class, got:\n{}",
+        options_py.content
+    );
+
+    // options.py MUST still define ConversionOptions (the input/config type).
+    assert!(
+        options_py.content.contains("class ConversionOptions"),
+        "options.py must still define ConversionOptions dataclass, got:\n{}",
+        options_py.content
+    );
 }

--- a/crates/alef-backend-rustler/src/gen_bindings.rs
+++ b/crates/alef-backend-rustler/src/gen_bindings.rs
@@ -663,12 +663,10 @@ fn gen_rustler_method_call_args(params: &[ParamDef], opaque_types: &AHashSet<Str
                     } else {
                         format!("{}.map(Into::into)", p.name)
                     }
+                } else if p.is_ref {
+                    format!("&{}.clone().into()", p.name)
                 } else {
-                    if p.is_ref {
-                        format!("&{}.clone().into()", p.name)
-                    } else {
-                        format!("{}.into()", p.name)
-                    }
+                    format!("{}.into()", p.name)
                 }
             }
             TypeRef::String | TypeRef::Char if p.optional && p.is_ref => {
@@ -788,13 +786,11 @@ fn gen_nif_function(
                             } else {
                                 format!("{}.map(Into::into)", p.name)
                             }
+                        } else if p.is_ref {
+                            // T where core expects &T → take reference of converted value
+                            format!("&{}.clone().into()", p.name)
                         } else {
-                            if p.is_ref {
-                                // T where core expects &T → take reference of converted value
-                                format!("&{}.clone().into()", p.name)
-                            } else {
-                                format!("{}.into()", p.name)
-                            }
+                            format!("{}.into()", p.name)
                         }
                     }
                     // String params: handle optional and reference cases.
@@ -955,12 +951,10 @@ fn gen_nif_async_function(
                             } else {
                                 format!("{}.map(Into::into)", p.name)
                             }
+                        } else if p.is_ref {
+                            format!("&{}.clone().into()", p.name)
                         } else {
-                            if p.is_ref {
-                                format!("&{}.clone().into()", p.name)
-                            } else {
-                                format!("{}.into()", p.name)
-                            }
+                            format!("{}.into()", p.name)
                         }
                     }
                     // String params: handle optional and reference cases.

--- a/crates/alef-cli/src/pipeline/extract.rs
+++ b/crates/alef-cli/src/pipeline/extract.rs
@@ -34,7 +34,7 @@ pub fn ensure_gitignore(base_dir: &Path, config: &AlefConfig) {
             Language::Java => entries.extend_from_slice(&["target/", "*.class"]),
             Language::Csharp => entries.extend_from_slice(&["bin/", "obj/", "*.nupkg"]),
             // pkg/ intentionally NOT gitignored — npm publish needs it for WASM artifacts
-            Language::Wasm => {},
+            Language::Wasm => {}
             _ => {}
         }
     }

--- a/crates/alef-codegen/src/generators/binding_helpers.rs
+++ b/crates/alef-codegen/src/generators/binding_helpers.rs
@@ -325,20 +325,18 @@ pub fn gen_call_args(params: &[ParamDef], opaque_types: &AHashSet<String>) -> St
                         } else {
                             p.name.clone()
                         }
+                    } else if promoted {
+                        format!("{}{}", p.name, unwrap_suffix)
+                    } else if p.is_mut && p.optional {
+                        format!("{}.as_deref_mut()", p.name)
+                    } else if p.is_mut {
+                        format!("&mut {}", p.name)
+                    } else if p.is_ref && p.optional {
+                        format!("{}.as_deref()", p.name)
+                    } else if p.is_ref {
+                        format!("&{}", p.name)
                     } else {
-                        if promoted {
-                            format!("{}{}", p.name, unwrap_suffix)
-                        } else if p.is_mut && p.optional {
-                            format!("{}.as_deref_mut()", p.name)
-                        } else if p.is_mut {
-                            format!("&mut {}", p.name)
-                        } else if p.is_ref && p.optional {
-                            format!("{}.as_deref()", p.name)
-                        } else if p.is_ref {
-                            format!("&{}", p.name)
-                        } else {
-                            p.name.clone()
-                        }
+                        p.name.clone()
                     }
                 }
                 _ => {
@@ -488,16 +486,14 @@ pub fn gen_call_args_with_let_bindings(params: &[ParamDef], opaque_types: &AHash
                         } else {
                             format!("{}_core", p.name)
                         }
+                    } else if promoted {
+                        format!("{}{}", p.name, unwrap_suffix)
+                    } else if p.is_ref && p.optional {
+                        format!("{}.as_deref()", p.name)
+                    } else if p.is_ref {
+                        format!("&{}", p.name)
                     } else {
-                        if promoted {
-                            format!("{}{}", p.name, unwrap_suffix)
-                        } else if p.is_ref && p.optional {
-                            format!("{}.as_deref()", p.name)
-                        } else if p.is_ref {
-                            format!("&{}", p.name)
-                        } else {
-                            p.name.clone()
-                        }
+                        p.name.clone()
                     }
                 }
                 _ => {

--- a/crates/alef-e2e/src/codegen/go.rs
+++ b/crates/alef-e2e/src/codegen/go.rs
@@ -586,12 +586,10 @@ fn render_assertion(
                     } else {
                         let _ = writeln!(out_ref, "\tif {trimmed_field} != {go_val} {{");
                     }
+                } else if is_optional && !field_expr.starts_with("len(") {
+                    let _ = writeln!(out_ref, "\tif {field_expr} != nil && {deref_field_expr} != {go_val} {{");
                 } else {
-                    if is_optional && !field_expr.starts_with("len(") {
-                        let _ = writeln!(out_ref, "\tif {field_expr} != nil && {deref_field_expr} != {go_val} {{");
-                    } else {
-                        let _ = writeln!(out_ref, "\tif {field_expr} != {go_val} {{");
-                    }
+                    let _ = writeln!(out_ref, "\tif {field_expr} != {go_val} {{");
                 }
                 let _ = writeln!(out_ref, "\t\tt.Errorf(\"equals mismatch: got %v\", {field_expr})");
                 let _ = writeln!(out_ref, "\t}}");

--- a/crates/alef-e2e/src/codegen/rust.rs
+++ b/crates/alef-e2e/src/codegen/rust.rs
@@ -322,7 +322,11 @@ fn render_test_function(
             arg.optional,
             &module,
             &fixture.id,
-            if has_mock { Some("mock_server.url.as_str()") } else { None },
+            if has_mock {
+                Some("mock_server.url.as_str()")
+            } else {
+                None
+            },
         );
         for binding in &bindings {
             let _ = writeln!(out, "    {binding}");
@@ -619,14 +623,8 @@ fn render_mock_server_setup(out: &mut String, fixture: &Fixture, e2e_config: &E2
 
     // Resolve the HTTP path and method from the call config.
     let call_config = e2e_config.resolve_call(fixture.call.as_deref());
-    let path = call_config
-        .path
-        .as_deref()
-        .unwrap_or("/");
-    let method = call_config
-        .method
-        .as_deref()
-        .unwrap_or("POST");
+    let path = call_config.path.as_deref().unwrap_or("/");
+    let method = call_config.method.as_deref().unwrap_or("POST");
 
     let status = mock.status;
 


### PR DESCRIPTION

  - Types with both has_default = true and is_return_type = true (e.g. ConversionResult) were incorrectly emitted as @dataclass shadow classes in options.py and re-exported from __init__.py via .options
  - At runtime functions return the native #[pyclass] struct; at type-check time Pylance saw the unrelated Python dataclass ,.. triggering a type mismatch error
  - gen_options_py: skip @dataclass emission for is_return_type = true types when DTO style is not TypedDict
  - gen_init_py: route those types to imports_from_native (from the native module) instead of config_types (from .options), consistent with how data enums are already handled

  test plan
  - New regression test test_return_type_exported_from_native_module_not_options asserts ConversionResult appears in native module import, not .options import, and that no shadow class is emitted in options.py
  - All 29 existing pyo3 backend tests pass
  - All core and backend crate tests pass
  - After merging, regenerate in kreuzberg-dev/html-to-markdown and verify Pylance no longer reports the type mismatch

  fixes #1 · reported in kreuzberg-dev/html-to-markdown#310