### PR TITLE
fix(codegen): prefix unused Map key with underscore

### DIFF
--- a/crates/alef-codegen/src/conversions/binding_to_core.rs
+++ b/crates/alef-codegen/src/conversions/binding_to_core.rs
@@ -602,7 +602,7 @@ pub fn field_conversion_to_core_cfg(name: &str, ty: &TypeRef, optional: bool, co
             }
         }
         // HashMap value type casting: when value type needs i64→core casting
-        TypeRef::Map(k, v)
+        TypeRef::Map(_k, v)
             if config.cast_large_ints_to_i64 && matches!(v.as_ref(), TypeRef::Primitive(p) if needs_i64_cast(p)) =>
         {
             if let TypeRef::Primitive(p) = v.as_ref() {

--- a/crates/alef-codegen/src/conversions/core_to_binding.rs
+++ b/crates/alef-codegen/src/conversions/core_to_binding.rs
@@ -584,7 +584,7 @@ pub fn field_conversion_from_core_cfg(
             }
         }
         // HashMap value type casting: when value type needs i64 casting
-        TypeRef::Map(k, v)
+        TypeRef::Map(_k, v)
             if config.cast_large_ints_to_i64 && matches!(v.as_ref(), TypeRef::Primitive(p) if needs_i64_cast(p)) =>
         {
             if let TypeRef::Primitive(p) = v.as_ref() {


### PR DESCRIPTION
## Summary

- The HashMap value-cast arms in `binding_to_core.rs:605` and `core_to_binding.rs:587` destructure `TypeRef::Map(k, v)` but only use `v` (the `k` inside the arm body is a separate closure binding that shadows it).
- Under `-D warnings` — which any downstream consumer doing `cargo install --git ... --locked --bin alef` effectively hits — this fails the build:

```
error: unused variable: `k`
  --> crates/alef-codegen/src/conversions/binding_to_core.rs:605:22
  --> crates/alef-codegen/src/conversions/core_to_binding.rs:587:22
error: could not compile `alef-codegen` (lib) due to 2 previous errors
```

- Rename the outer binding to `_k`. No behavior change, no codegen change — purely a lint fix.

This currently blocks CI in `kreuzberg-dev/tree-sitter-language-pack` (and any repo pinning `alef` v0.6.0 / v0.6.1 / main).

## Test plan

- [x] `cargo build -p alef-codegen` (dev)
- [x] `RUSTFLAGS="-D warnings" cargo build -p alef-codegen --release`
- [ ] CI green on this PR