### PR TITLE
docs: update liter-llm binding count to 16 languages in ecosystem block

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,7 @@ prek run --all-files
   HTML-to-Markdown and headless Chrome fallback.
 - [html-to-markdown](https://github.com/kreuzberg-dev/html-to-markdown) - fast, lossless
   HTML-to-Markdown conversion.
-- [liter-llm](https://github.com/kreuzberg-dev/liter-llm) - universal LLM API client with native
-  bindings.
+- [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 16 languages and 143 providers.
 - [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sitter-language-pack) -
   tree-sitter grammars and code-intelligence primitives.
 - [Discord](https://discord.gg/xt9WY3GnKR) - community, roadmap, and release discussion.


### PR DESCRIPTION
Corrects liter-llm language count from 14 to 16 in the alef README ecosystem block.