### PR TITLE
fix(pyo3): reliable Python trait callbacks (sync GIL, contextvars, errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **PyO3: sync entrypoints and sync free functions now release the GIL across the blocking core
+  call.** When core re-enters Python through a registered trait callback (the bridge runs the host
+  callback on a `spawn_blocking` worker thread that re-acquires the GIL), the worker could never
+  obtain the GIL the sync entrypoint thread held while parked in the blocking call, deadlocking the
+  callback. Generated sync service entrypoints now wrap the core call in `_py.detach(|| ...)`, and
+  generated sync `#[pyfunction]` free functions take an injected `py: Python<'_>` and wrap the core
+  call in `py.detach(|| ...)`. The async path already released the GIL via `future_into_py`.
+  (`backends/pyo3/gen_bindings/service_api/rust_service.rs`, `codegen/generators/functions.rs`)
+
 ## [0.26.5] - 2026-06-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   generated sync `#[pyfunction]` free functions take an injected `py: Python<'_>` and wrap the core
   call in `py.detach(|| ...)`. The async path already released the GIL via `future_into_py`.
   (`backends/pyo3/gen_bindings/service_api/rust_service.rs`, `codegen/generators/functions.rs`)
+- **PyO3: trait callbacks now run inside the caller's contextvars Context.** The bridge ran the
+  host callback on a `spawn_blocking` worker thread with a fresh, empty `contextvars` context, so
+  any `ContextVar` set by the caller was invisible inside the callback. The bridge now captures
+  `contextvars.copy_context()` on the calling thread and invokes the host method via
+  `ctx.run(bound_method, *args)` for both sync and async trait methods.
+  (`backends/pyo3/trait_bridge/generator.rs`, `backends/pyo3/templates/trait_bridge/*.jinja`)
 
 ## [0.26.5] - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `contextvars.copy_context()` on the calling thread and invokes the host method via
   `ctx.run(bound_method, *args)` for both sync and async trait methods.
   (`backends/pyo3/trait_bridge/generator.rs`, `backends/pyo3/templates/trait_bridge/*.jinja`)
+- **PyO3: trait-callback deserialization errors now name the expected return type.** When a host
+  trait method returns a value that does not match its struct return type, the bridge deserializes
+  the JSON-dumped value with `serde_json::from_str::<ReturnType>(...)`; the failure previously read
+  "deserialization failed: <serde error>" with no guidance. The message now names the expected
+  return type and hints that the value must be a mapping matching the type's fields. The serde
+  error continues to carry the offending field/path. (`backends/pyo3/trait_bridge/generator.rs`,
+  `backends/pyo3/templates/trait_bridge/sync_method_non_unit_return.jinja`)
 
 ## [0.26.5] - 2026-06-23
 

--- a/src/backends/pyo3/gen_bindings/functions/tests.rs
+++ b/src/backends/pyo3/gen_bindings/functions/tests.rs
@@ -1,6 +1,48 @@
 use super::{classify_param_type, emit_param_conversion};
 use crate::core::ir::TypeRef;
 
+/// Sync PyO3 free functions must release the GIL across the blocking core call so a
+/// trait callback re-entering Python from a worker thread cannot deadlock. The generated
+/// sync free function must (1) take an injected `py: Python<'_>` handle and (2) wrap the
+/// core call in `py.detach(|| ...)`. This is a regression test for issue #136.
+#[test]
+fn sync_pyo3_free_fn_releases_gil_around_core_call() {
+    use crate::codegen::generators::gen_function;
+    use crate::core::ir::{FunctionDef, ParamDef};
+
+    let func = FunctionDef {
+        name: "count_words".to_owned(),
+        rust_path: "sample_core::count_words".to_owned(),
+        params: vec![ParamDef {
+            name: "text".to_owned(),
+            ty: TypeRef::String,
+            optional: false,
+            default: None,
+            ..ParamDef::default()
+        }],
+        return_type: TypeRef::Primitive(crate::core::ir::PrimitiveType::U64),
+        is_async: false,
+        error_type: None,
+        ..FunctionDef::default()
+    };
+
+    let mapper = crate::backends::pyo3::type_map::Pyo3Mapper::new();
+    let cfg = crate::backends::pyo3::gen_bindings::config::binding_config("sample_core", true);
+    let adapter_bodies = ahash::AHashMap::new();
+    let opaque_types = ahash::AHashSet::new();
+
+    let output = gen_function(&func, &mapper, &cfg, &adapter_bodies, &opaque_types);
+
+    assert!(
+        output.contains("py: Python<'_>"),
+        "expected injected `py: Python<'_>` handle on sync free function:\n{output}"
+    );
+    assert!(
+        output.contains("py.detach(|| sample_core::count_words("),
+        "expected core call wrapped in `py.detach(|| ...)`:\n{output}"
+    );
+}
+
 /// classify_param_type returns Plain for a bare Named type.
 #[test]
 fn classify_param_type_returns_plain_for_named() {

--- a/src/backends/pyo3/gen_bindings/service_api.rs
+++ b/src/backends/pyo3/gen_bindings/service_api.rs
@@ -433,6 +433,21 @@ mod tests {
         );
     }
 
+    /// Sync entrypoints must release the GIL around the blocking core call so a
+    /// trait callback re-entering Python from a worker thread cannot deadlock on
+    /// the GIL the entrypoint thread holds. The `into_router` fixture entrypoint
+    /// is sync; its core call must be wrapped in `_py.detach(|| ...)`.
+    #[test]
+    fn rust_sync_entrypoint_releases_gil_around_core_call() {
+        let surface = make_fixture_surface();
+        let config = make_test_config();
+        let output = gen_service_rs(&surface, &config);
+        assert!(
+            output.contains("_py.detach(|| owner.into_router())"),
+            "expected sync entrypoint core call wrapped in `_py.detach(|| ...)`:\n{output}"
+        );
+    }
+
     /// `gen_service_rs` emits registration dispatch via `match method_name`.
     #[test]
     fn rust_output_contains_registration_dispatch() {

--- a/src/backends/pyo3/gen_bindings/service_api/rust_service.rs
+++ b/src/backends/pyo3/gen_bindings/service_api/rust_service.rs
@@ -350,12 +350,17 @@ fn build_ep_call(ep: &crate::core::ir::EntrypointDef, _service: &ServiceDef, _co
              .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;\n"
         )
     } else if ep.error_type.is_some() {
+        // Sync entrypoint: release the GIL across the blocking core call. A trait callback
+        // re-entering Python from a `spawn_blocking` worker thread would otherwise deadlock
+        // trying to acquire the GIL this thread holds. `detach` releases it only for the
+        // closure, which touches no Python objects (Rust args in, Rust value out).
         format!(
-            "    {bind}owner.{ep_method}({args_str})\n        \
+            "    {bind}_py.detach(|| owner.{ep_method}({args_str}))\n        \
              .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;\n"
         )
     } else {
-        format!("    {bind}owner.{ep_method}({args_str});\n")
+        // Sync entrypoint: release the GIL across the blocking core call (see above).
+        format!("    {bind}_py.detach(|| owner.{ep_method}({args_str}));\n")
     }
 }
 

--- a/src/backends/pyo3/templates/trait_bridge/async_method_named_return.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/async_method_named_return.jinja
@@ -1,4 +1,9 @@
 let python_obj = Python::attach(|py| self.inner.clone_ref(py));
+let caller_ctx = Python::attach(|py| {
+    py.import("contextvars")
+        .and_then(|m| m.call_method0("copy_context"))
+        .map(|c| c.unbind())
+});
 let cached_name = self.cached_name.clone();
 
 {{ param_cloning }}
@@ -6,9 +11,10 @@ let cached_name = self.cached_name.clone();
 tokio::task::spawn_blocking(move || {
     Python::attach(|py| {
         let obj = python_obj.bind(py);
+        let ctx = caller_ctx.map_err(|e| {{ error_expr }})?.into_bound(py);
 
-        {{ py_call }}
-        let py_result = {{ call }}
+        let bound_method = obj.getattr("{{ method_name }}").map_err(|e| {{ error_expr }})?;
+        let py_result = ctx.call_method1("run", ({{ run_args }}))
             .map_err(|e| {{ error_expr }})?;
         let json_val: String = py
             .import("json")

--- a/src/backends/pyo3/templates/trait_bridge/async_method_non_unit_return.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/async_method_non_unit_return.jinja
@@ -1,4 +1,9 @@
 let python_obj = Python::attach(|py| self.inner.clone_ref(py));
+let caller_ctx = Python::attach(|py| {
+    py.import("contextvars")
+        .and_then(|m| m.call_method0("copy_context"))
+        .map(|c| c.unbind())
+});
 let cached_name = self.cached_name.clone();
 
 {{ param_cloning }}
@@ -6,8 +11,10 @@ let cached_name = self.cached_name.clone();
 tokio::task::spawn_blocking(move || {
     Python::attach(|py| {
         let obj = python_obj.bind(py);
+        let ctx = caller_ctx.map_err(|e| {{ error_expr }})?.into_bound(py);
 
-        {{ call }}
+        let bound_method = obj.getattr("{{ method_name }}").map_err(|e| {{ error_expr }})?;
+        ctx.call_method1("run", ({{ run_args }}))
             .and_then(|v| v.extract::<{{ extract_ty }}>())
             .map_err(|e| {{ error_expr }})
     })

--- a/src/backends/pyo3/templates/trait_bridge/async_method_unit_return.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/async_method_unit_return.jinja
@@ -1,4 +1,9 @@
 let python_obj = Python::attach(|py| self.inner.clone_ref(py));
+let caller_ctx = Python::attach(|py| {
+    py.import("contextvars")
+        .and_then(|m| m.call_method0("copy_context"))
+        .map(|c| c.unbind())
+});
 let cached_name = self.cached_name.clone();
 
 {{ param_cloning }}
@@ -6,8 +11,10 @@ let cached_name = self.cached_name.clone();
 tokio::task::spawn_blocking(move || {
     Python::attach(|py| {
         let obj = python_obj.bind(py);
+        let ctx = caller_ctx.map_err(|e| {{ error_expr }})?.into_bound(py);
 
-        {{ call }}
+        let bound_method = obj.getattr("{{ method_name }}").map_err(|e| {{ error_expr }})?;
+        ctx.call_method1("run", ({{ run_args }}))
             .map(|_| ())
             .map_err(|e| {{ error_expr }})
     })

--- a/src/backends/pyo3/templates/trait_bridge/sync_method_non_unit_return.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/sync_method_non_unit_return.jinja
@@ -1,5 +1,11 @@
 Python::attach(|py| {
-    {{ call }}
+    let obj = self.inner.bind(py);
+    py.import("contextvars")
+        .and_then(|m| m.call_method0("copy_context"))
+        .and_then(|ctx| {
+            let bound_method = obj.getattr("{{ method_name }}")?;
+            ctx.call_method1("run", ({{ run_args }}))
+        })
 {% if is_named %}
         .and_then(|v| v.extract::<String>())
         .and_then(|s| serde_json::from_str::<{{ extract_ty }}>(&s).map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())))

--- a/src/backends/pyo3/templates/trait_bridge/sync_method_non_unit_return.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/sync_method_non_unit_return.jinja
@@ -8,7 +8,7 @@ Python::attach(|py| {
         })
 {% if is_named %}
         .and_then(|v| v.extract::<String>())
-        .and_then(|s| serde_json::from_str::<{{ extract_ty }}>(&s).map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())))
+        .and_then(|s| serde_json::from_str::<{{ extract_ty }}>(&s).map_err(|e| {{ deserialize_error_expr }}))
 {% else %}
         .and_then(|v| v.extract::<{{ extract_ty }}>())
 {% endif %}

--- a/src/backends/pyo3/templates/trait_bridge/sync_method_unit_return.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/sync_method_unit_return.jinja
@@ -1,5 +1,11 @@
 Python::attach(|py| {
-    {{ call }}
+    let obj = self.inner.bind(py);
+    py.import("contextvars")
+        .and_then(|m| m.call_method0("copy_context"))
+        .and_then(|ctx| {
+            let bound_method = obj.getattr("{{ method_name }}")?;
+            ctx.call_method1("run", ({{ run_args }}))
+        })
         .map(|_| ())
 {% if has_error %}
         .map_err(|e| {{ error_expr }})

--- a/src/backends/pyo3/trait_bridge.rs
+++ b/src/backends/pyo3/trait_bridge.rs
@@ -105,6 +105,82 @@ pub fn gen_trait_bridge(
 // - No registration function is needed (per-call construction via `type_alias`)
 
 mod tests {
+    /// Trait callbacks must run inside the caller's contextvars Context so any ContextVar
+    /// set by the caller is visible inside the callback. The generated bridge body must capture
+    /// `contextvars.copy_context()` and invoke the host method via `ctx.run(bound_method, ...)`
+    /// (rendered as `call_method1("run", ...)`) rather than calling the method directly.
+    /// Regression test for issue #137.
+    #[test]
+    fn trait_callback_runs_in_caller_contextvars_context() {
+        use crate::codegen::generators::trait_bridge::{TraitBridgeGenerator, TraitBridgeSpec};
+        use crate::core::config::TraitBridgeConfig;
+        use crate::core::ir::{MethodDef, ParamDef, ReceiverKind, TypeDef, TypeRef};
+        use std::collections::{HashMap, HashSet};
+
+        let trait_def = TypeDef {
+            name: "SampleService".to_owned(),
+            rust_path: "sample_core::SampleService".to_owned(),
+            is_trait: true,
+            is_opaque: true,
+            ..TypeDef::default()
+        };
+        let bridge_cfg = TraitBridgeConfig {
+            trait_name: "SampleService".to_owned(),
+            register_fn: Some("register_sample".to_owned()),
+            registry_getter: Some("sample_core::registry::get".to_owned()),
+            ..TraitBridgeConfig::default()
+        };
+        let spec = TraitBridgeSpec {
+            trait_def: &trait_def,
+            bridge_config: &bridge_cfg,
+            core_import: "sample_core",
+            wrapper_prefix: "Py",
+            type_paths: HashMap::new(),
+            lifetime_type_names: HashSet::new(),
+            error_type: "SampleError".to_owned(),
+            error_constructor: "SampleError::Message { message: {msg} }".to_owned(),
+        };
+        let generator = super::Pyo3BridgeGenerator {
+            core_import: "sample_core".to_owned(),
+            type_paths: HashMap::new(),
+            error_type: "SampleError".to_owned(),
+        };
+
+        let make_method = |is_async: bool| MethodDef {
+            name: "process".to_owned(),
+            params: vec![ParamDef {
+                name: "text".to_owned(),
+                ty: TypeRef::String,
+                ..ParamDef::default()
+            }],
+            return_type: TypeRef::String,
+            is_async,
+            error_type: Some("SampleError".to_owned()),
+            receiver: Some(ReceiverKind::Ref),
+            ..MethodDef::default()
+        };
+
+        let async_body = generator.gen_async_method_body(&make_method(true), &spec);
+        assert!(
+            async_body.contains("copy_context"),
+            "async bridge must capture the caller's contextvars context:\n{async_body}"
+        );
+        assert!(
+            async_body.contains("call_method1(\"run\""),
+            "async bridge must invoke the host method via ctx.run:\n{async_body}"
+        );
+
+        let sync_body = generator.gen_sync_method_body(&make_method(false), &spec);
+        assert!(
+            sync_body.contains("copy_context"),
+            "sync bridge must capture the caller's contextvars context:\n{sync_body}"
+        );
+        assert!(
+            sync_body.contains("call_method1(\"run\""),
+            "sync bridge must invoke the host method via ctx.run:\n{sync_body}"
+        );
+    }
+
     #[test]
     fn visitor_bridge_uses_configured_context_and_result_metadata() {
         let (api, trait_type, bridge) = crate::codegen::visitor_context::test_support::neutral_visitor_fixture();

--- a/src/backends/pyo3/trait_bridge.rs
+++ b/src/backends/pyo3/trait_bridge.rs
@@ -181,6 +181,75 @@ mod tests {
         );
     }
 
+    /// When a host returns a value that does not match a struct return type, the bridge
+    /// deserializes it via `serde_json::from_str::<ReturnType>(...)`. The failure message must
+    /// name the expected return TYPE and hint that the value must be a mapping matching the
+    /// type's fields, so the host can fix their return value. The serde error (`{e}`) already
+    /// carries the offending field/path. Regression test for issue #138.
+    #[test]
+    fn trait_callback_deserialize_error_names_return_type() {
+        use crate::codegen::generators::trait_bridge::{TraitBridgeGenerator, TraitBridgeSpec};
+        use crate::core::config::TraitBridgeConfig;
+        use crate::core::ir::{MethodDef, ReceiverKind, TypeDef, TypeRef};
+        use std::collections::{HashMap, HashSet};
+
+        let trait_def = TypeDef {
+            name: "SampleService".to_owned(),
+            rust_path: "sample_core::SampleService".to_owned(),
+            is_trait: true,
+            is_opaque: true,
+            ..TypeDef::default()
+        };
+        let bridge_cfg = TraitBridgeConfig {
+            trait_name: "SampleService".to_owned(),
+            register_fn: Some("register_sample".to_owned()),
+            registry_getter: Some("sample_core::registry::get".to_owned()),
+            ..TraitBridgeConfig::default()
+        };
+        let spec = TraitBridgeSpec {
+            trait_def: &trait_def,
+            bridge_config: &bridge_cfg,
+            core_import: "sample_core",
+            wrapper_prefix: "Py",
+            type_paths: HashMap::new(),
+            lifetime_type_names: HashSet::new(),
+            error_type: "SampleError".to_owned(),
+            error_constructor: "SampleError::Message { message: {msg} }".to_owned(),
+        };
+        let generator = super::Pyo3BridgeGenerator {
+            core_import: "sample_core".to_owned(),
+            type_paths: HashMap::new(),
+            error_type: "SampleError".to_owned(),
+        };
+
+        // A trait method returning a struct `Doc` exercises the json.dumps -> from_str path.
+        let make_method = |is_async: bool| MethodDef {
+            name: "build".to_owned(),
+            params: vec![],
+            return_type: TypeRef::Named("Doc".to_owned()),
+            is_async,
+            error_type: Some("SampleError".to_owned()),
+            receiver: Some(ReceiverKind::Ref),
+            ..MethodDef::default()
+        };
+
+        for is_async in [true, false] {
+            let body = if is_async {
+                generator.gen_async_method_body(&make_method(true), &spec)
+            } else {
+                generator.gen_sync_method_body(&make_method(false), &spec)
+            };
+            assert!(
+                body.contains("expected return type `Doc`"),
+                "deserialize error must name the expected return type `Doc` (is_async={is_async}):\n{body}"
+            );
+            assert!(
+                body.contains("must be a mapping"),
+                "deserialize error must hint the value must be a mapping matching the type's fields (is_async={is_async}):\n{body}"
+            );
+        }
+    }
+
     #[test]
     fn visitor_bridge_uses_configured_context_and_result_metadata() {
         let (api, trait_type, bridge) = crate::codegen::visitor_context::test_support::neutral_visitor_fixture();

--- a/src/backends/pyo3/trait_bridge/generator.rs
+++ b/src/backends/pyo3/trait_bridge/generator.rs
@@ -31,6 +31,16 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
         let has_error = method.error_type.is_some();
 
         let py_args = self.sync_py_args(method);
+        // Invoke the host method through the caller's contextvars Context so any ContextVar
+        // set by the caller is visible inside the callback. `ctx.run(bound_method, *args)`
+        // runs the callable with `ctx` as the active context; calling the method directly
+        // would run it under the worker/empty context instead. The trailing comma keeps the
+        // zero-arg case a 1-tuple `(bound_method,)` rather than a parenthesized expression.
+        let run_args = if py_args.is_empty() {
+            "bound_method,".to_string()
+        } else {
+            format!("bound_method, {py_args}")
+        };
         let call = if py_args.is_empty() {
             format!("self.inner.bind(py).call_method0(\"{name}\")")
         } else {
@@ -46,6 +56,7 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
                 minijinja::context! {
                     method_name => name,
                     call => call,
+                    run_args => run_args,
                     has_error => has_error,
                     error_expr => error_expr,
                 },
@@ -58,6 +69,7 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
                 minijinja::context! {
                     method_name => name,
                     call => call,
+                    run_args => run_args,
                     is_named => is_named,
                     extract_ty => ext,
                     has_error => has_error,
@@ -103,6 +115,15 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
         );
 
         let py_args = self.async_py_args(method);
+        // Run the host method through the caller's contextvars Context (captured on the calling
+        // thread before `spawn_blocking`) so the callback sees the caller's ContextVars rather
+        // than the worker thread's fresh, empty context. The trailing comma keeps the zero-arg
+        // case a 1-tuple `(bound_method,)` rather than a parenthesized expression.
+        let run_args = if py_args.is_empty() {
+            "bound_method,".to_string()
+        } else {
+            format!("bound_method, {py_args}")
+        };
         let call = if py_args.is_empty() {
             format!("obj.call_method0(\"{name}\")")
         } else {
@@ -125,6 +146,7 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
                 minijinja::context! {
                     method_name => name,
                     call => call,
+                    run_args => run_args,
                     param_cloning => param_cloning,
                     return_type => return_type,
                     error_expr => error_expr,
@@ -139,6 +161,7 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
                 minijinja::context! {
                     method_name => name,
                     call => call,
+                    run_args => run_args,
                     param_cloning => param_cloning,
                     error_expr => error_expr,
                     spawn_error_expr => spawn_error_expr,
@@ -151,6 +174,7 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
                 minijinja::context! {
                     method_name => name,
                     call => call,
+                    run_args => run_args,
                     extract_ty => ext,
                     param_cloning => param_cloning,
                     error_expr => error_expr,

--- a/src/backends/pyo3/trait_bridge/generator.rs
+++ b/src/backends/pyo3/trait_bridge/generator.rs
@@ -64,6 +64,13 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
         } else {
             let ext = self.extract_ty(&method.return_type);
             let is_named = matches!(method.return_type, TypeRef::Named(_));
+            // Name the expected return type and hint the shape so a host returning a mismatched
+            // value can fix it. This is a PyErr (the sync chain is `PyResult`-typed before the
+            // final `map_err`); the serde error (`{}`) already names the offending field/path.
+            let return_type_name = self.return_type_display_name(&method.return_type);
+            let deserialize_error_expr = format!(
+                "pyo3::exceptions::PyRuntimeError::new_err(format!(\"method '{name}' returned a value that does not match the expected return type `{return_type_name}`: {{}}. The returned value must be a mapping matching the fields of `{return_type_name}`.\", e))"
+            );
             crate::backends::pyo3::template_env::render(
                 "trait_bridge/sync_method_non_unit_return.jinja",
                 minijinja::context! {
@@ -74,6 +81,7 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
                     extract_ty => ext,
                     has_error => has_error,
                     error_expr => error_expr,
+                    deserialize_error_expr => deserialize_error_expr,
                 },
             )
         }
@@ -134,8 +142,13 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
         ));
         let json_error_expr =
             spec.make_error("format!(\"Plugin '{}': JSON serialization failed: {}\", cached_name, e)");
-        let deserialize_error_expr =
-            spec.make_error("format!(\"Plugin '{}': deserialization failed: {}\", cached_name, e)");
+        // Name the expected return type and hint the shape so a host returning a mismatched
+        // value can fix it. The serde error (`{}`) already names the offending field/path
+        // (e.g. "missing field `title`" / "invalid type ... at line L column C").
+        let return_type_name = self.return_type_display_name(&method.return_type);
+        let deserialize_error_expr = spec.make_error(&format!(
+            "format!(\"Plugin '{{}}' method '{name}' returned a value that does not match the expected return type `{return_type_name}`: {{}}. The returned value must be a mapping matching the fields of `{return_type_name}`.\", cached_name, e)"
+        ));
         let spawn_error_expr = spec.make_error("format!(\"spawn_blocking failed: {}\", e)");
 
         if self.is_named(&method.return_type) {
@@ -273,6 +286,17 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
 }
 
 impl Pyo3BridgeGenerator {
+    /// Human-facing name of a return type for callback deserialization error messages.
+    /// For a `Named` type this is the bare type name (e.g. `Doc`), not the fully-qualified
+    /// Rust path, so the message reads the way a host implementer thinks about their return
+    /// value. Other shapes fall back to their Rust rendering.
+    fn return_type_display_name(&self, ty: &TypeRef) -> String {
+        match ty {
+            TypeRef::Named(name) => name.clone(),
+            other => self.extract_ty(other),
+        }
+    }
+
     /// Extract the Python type that corresponds to a Rust TypeRef.
     fn extract_ty(&self, ty: &TypeRef) -> String {
         match ty {

--- a/src/codegen/generators/functions.rs
+++ b/src/codegen/generators/functions.rs
@@ -187,6 +187,22 @@ pub fn gen_function_with_mutex(
     let can_delegate = crate::codegen::shared::can_auto_delegate_function(func, opaque_types)
         || can_delegate_with_named_let_bindings(func, opaque_types);
 
+    // PyO3 sync free functions hold the GIL while calling into core. When core re-enters
+    // Python via a registered trait callback (the bridge runs the host callback on a
+    // `spawn_blocking` worker thread that re-acquires the GIL), the worker can never get the
+    // GIL this thread holds while parked in the blocking call → deadlock. Release the GIL
+    // for the duration of the blocking core call by wrapping it in `py.detach(|| ...)`. The
+    // closure touches no Python objects (Rust args in, Rust value out); conversion to Python
+    // happens after the call returns. The async path already releases the GIL via future_into_py.
+    let pyo3_sync = !func.is_async && cfg.async_pattern == AsyncPattern::Pyo3FutureIntoPy;
+    let detach_core_call = |core_call: &str| -> String {
+        if pyo3_sync {
+            format!("py.detach(|| {core_call})")
+        } else {
+            core_call.to_string()
+        }
+    };
+
     // Backend-specific error conversion string for serde bindings
     let serde_err_conv = match cfg.async_pattern {
         AsyncPattern::Pyo3FutureIntoPy => ".map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))",
@@ -219,7 +235,9 @@ pub fn gen_function_with_mutex(
             };
             let serde_bindings =
                 gen_serde_let_bindings(&func.params, opaque_types, core_import, serde_err_async, serde_indent);
-            let core_call = format!("{core_fn_path}({call_args})");
+            // For sync PyO3 the blocking core call is wrapped in `py.detach(|| ...)` to release
+            // the GIL (no-op for async/other backends; the async path uses future_into_py).
+            let core_call = detach_core_call(&format!("{core_fn_path}({call_args})"));
 
             // Determine return wrapping strategy for serde async (uses explicit types to avoid E0283)
             let returns_ref = func.returns_ref;
@@ -423,7 +441,9 @@ pub fn gen_function_with_mutex(
             format!("{let_bindings}{async_body}")
         }
     } else {
-        let core_call = format!("{core_fn_path}({call_args})");
+        // For sync PyO3 the blocking core call is wrapped in `py.detach(|| ...)` to release
+        // the GIL (no-op for other backends).
+        let core_call = detach_core_call(&format!("{core_fn_path}({call_args})"));
 
         // Check if we need to cast primitives due to type mapping (e.g., u32 → i32 for extendr)
         let cast_suffix = match &func.return_type {
@@ -674,6 +694,11 @@ pub fn gen_function_with_mutex(
     };
     let func_lifetime = if func_needs_py { "<'py>" } else { "" };
 
+    // Sync PyO3 free functions take an injected `py: Python<'_>` handle so the body can call
+    // `py.detach(...)` to release the GIL across the blocking core call (see `pyo3_sync` above).
+    // PyO3 supplies this argument automatically; it is excluded from `#[pyo3(signature = (...))]`.
+    let sync_py_prefix = if pyo3_sync { "py: Python<'_>, " } else { "" };
+
     let (func_sig, _params_formatted) = if params.len() > 100 {
         // Wrap the signature across multiple lines for readability. Reuse the exact
         // per-parameter strings computed above (`param_strings`) — recomputing the types here
@@ -695,7 +720,7 @@ pub fn gen_function_with_mutex(
         } else {
             (
                 format!(
-                    "pub {async_kw}fn {}(\n    {}\n) -> {ret}",
+                    "pub {async_kw}fn {}(\n    {sync_py_prefix}{}\n) -> {ret}",
                     func.name,
                     wrapped_params,
                     ret = ret
@@ -712,10 +737,13 @@ pub fn gen_function_with_mutex(
             "",
         )
     } else {
-        (format!("pub {async_kw}fn {}({params}) -> {ret}", func.name), "")
+        (
+            format!("pub {async_kw}fn {}({sync_py_prefix}{params}) -> {ret}", func.name),
+            "",
+        )
     };
 
-    let total_params = func.params.len() + if func_needs_py { 1 } else { 0 };
+    let total_params = func.params.len() + if func_needs_py || pyo3_sync { 1 } else { 0 };
     let sig_defaults = if cfg.needs_signature {
         function_sig_defaults(&func.params)
     } else {

--- a/tests/backends_pyo3_gen_bindings/trait_bridge_methods.rs
+++ b/tests/backends_pyo3_gen_bindings/trait_bridge_methods.rs
@@ -53,7 +53,10 @@ fn test_gen_sync_method_body_string_return_no_error() {
     let method = make_method_def("name", vec![], TypeRef::String, false, false, false);
     let body = generator.gen_sync_method_body(&method, &spec);
 
-    assert!(body.contains("getattr(\"name\")"), "should resolve the host method by name");
+    assert!(
+        body.contains("getattr(\"name\")"),
+        "should resolve the host method by name"
+    );
     assert!(
         body.contains("call_method1(\"run\""),
         "should invoke the host method via the caller's contextvars context"

--- a/tests/backends_pyo3_gen_bindings/trait_bridge_methods.rs
+++ b/tests/backends_pyo3_gen_bindings/trait_bridge_methods.rs
@@ -25,8 +25,8 @@ fn test_gen_sync_method_body_unit_return_no_error() {
 
     assert!(body.contains("Python::attach"), "sync body should use Python::attach");
     assert!(
-        body.contains("call_method0(\"tick\")"),
-        "should call Python method by name with no args"
+        body.contains("getattr(\"tick\")") && body.contains("call_method1(\"run\""),
+        "should resolve the host method by name and invoke it via the caller's contextvars context"
     );
     assert!(
         body.contains("unwrap_or(())"),
@@ -53,7 +53,11 @@ fn test_gen_sync_method_body_string_return_no_error() {
     let method = make_method_def("name", vec![], TypeRef::String, false, false, false);
     let body = generator.gen_sync_method_body(&method, &spec);
 
-    assert!(body.contains("call_method0(\"name\")"), "should call method by name");
+    assert!(body.contains("getattr(\"name\")"), "should resolve the host method by name");
+    assert!(
+        body.contains("call_method1(\"run\""),
+        "should invoke the host method via the caller's contextvars context"
+    );
     assert!(body.contains("extract::<String>()"), "should extract String return");
     assert!(
         body.contains("unwrap_or_default()"),
@@ -62,7 +66,7 @@ fn test_gen_sync_method_body_string_return_no_error() {
 }
 
 #[test]
-fn test_gen_sync_method_body_with_params_uses_call_method1() {
+fn test_gen_sync_method_body_with_params_runs_via_contextvars() {
     let generator = make_bridge_generator("my_lib");
     let trait_def = make_trait_def("MyTrait", "my_lib::MyTrait", vec![]);
     let bridge_cfg = make_bridge_cfg("MyTrait");
@@ -88,8 +92,12 @@ fn test_gen_sync_method_body_with_params_uses_call_method1() {
     let body = generator.gen_sync_method_body(&method, &spec);
 
     assert!(
-        body.contains("call_method1(\"process\""),
-        "single-param method should use call_method1"
+        body.contains("getattr(\"process\")"),
+        "single-param method should resolve the host method by name"
+    );
+    assert!(
+        body.contains("call_method1(\"run\", (bound_method, input"),
+        "single-param method should forward args through the caller's contextvars context"
     );
 }
 


### PR DESCRIPTION
Host code can register a trait object — for example a custom OCR backend — that the Rust core calls back into. Three independent defects in the pyo3 backend made that unreliable from Python. Each is a separate commit with a regression test.

## Sync entrypoints deadlocked on a callback (#136)

**Problem.** A generated synchronous entrypoint held the GIL for the whole call. When the core re-entered Python through a registered trait callback — which runs on a worker thread via `spawn_blocking` + `Python::attach` — that worker could never acquire the GIL the entrypoint thread was holding while parked in `block_on`, so the call hung. The async entrypoint was fine, because awaiting releases the GIL.

**Solution.** Generated sync entrypoints (service entrypoints and free functions) now release the GIL around the blocking core call with `py.detach(...)`, the same way the async path already did. The detached closure touches no Python objects — arguments are converted to Rust before it and the result is converted after — so it stays sound. The change is gated to the pyo3 sync path; other backends emit unchanged code.

## Callbacks lost the caller's contextvars (#137)

**Problem.** The trait bridge ran the host callback inside `spawn_blocking`, on a worker thread with a fresh, empty `contextvars` context. Anything the caller set — a request id, a trace/log context — was invisible inside the callback, with no error to hint at why.

**Solution.** Capture the caller's context with `contextvars.copy_context()` and invoke the host method through `Context.run(...)`, so the callback observes the same contextvars as the caller.

## Callback-return errors were cryptic (#138)

**Problem.** When a host method returned a value that didn't match the Rust return type, the JSON round-trip failed with a bare "deserialization failed" and no indication of what shape was expected.

**Solution.** The error now names the expected return type and notes that the value must be a mapping matching that type's fields, while preserving serde's field/path detail.

Cross-backend audit: the deadlock fix is pyo3-only (magnus releases the GVL, and jni/napi/rustler are safe by construction). Regression tests use neutral fixtures; the contextvars and error changes live in the trait-bridge templates.

Closes #136, #137, #138.
