### PR TITLE
fix(pyo3): export result types as native pyclasses under TypedDict style

### DIFF
--- a/src/backends/pyo3/gen_bindings/errors.rs
+++ b/src/backends/pyo3/gen_bindings/errors.rs
@@ -139,6 +139,7 @@ pub(super) fn gen_init_py(
     module_name: &str,
     version: &str,
     dto: &DtoConfig,
+    reexported_types: &[String],
     trait_bridges: &[crate::core::config::TraitBridgeConfig],
     extra_init_imports: &std::collections::BTreeMap<String, Vec<String>>,
     capsule_types: &std::collections::HashMap<String, crate::core::config::CapsuleTypeConfig>,
@@ -170,16 +171,21 @@ pub(super) fn gen_init_py(
     let mut needed_data_enums: Vec<String> = Vec::new();
     let mut config_types: Vec<String> = Vec::new();
     // Return types with is_return_type=true are defined authoritatively in the native Rust
-    // module. When not using TypedDict style (which emits a structural type in options.py),
-    // they must be re-exported from the native module — not from .options — so that the
-    // type seen by static analysis tools matches the actual runtime object returned by functions.
+    // module and are returned to callers as attribute-access pyclasses. They must be re-exported
+    // from the native module — not from .options — so the type seen by static analysis matches
+    // the runtime object. Under the structural (TypedDict) style every other type is emitted in
+    // options.py, so only the curated `reexported_types` results stay native; a config type that
+    // is also `is_return_type` (e.g. `ExtractionConfig`, returned by a resolver yet built by the
+    // caller) is not listed there and remains a structural type.
+    let reexported_names: AHashSet<&str> = reexported_types.iter().map(String::as_str).collect();
     let mut native_return_types: Vec<String> = Vec::new();
     for typ in api.types.iter().filter(|typ| !typ.is_trait && !typ.binding_excluded) {
         if typ.name.ends_with("Builder") {
             continue;
         }
         if typ.has_default && !typ.name.ends_with("Update") && !typ.fields.is_empty() {
-            let is_native_return = typ.is_return_type && output_style != PythonDtoStyle::TypedDict;
+            let is_native_return = typ.is_return_type
+                && (output_style != PythonDtoStyle::TypedDict || reexported_names.contains(typ.name.as_str()));
             if is_native_return {
                 native_return_types.push(typ.name.clone());
             } else {
@@ -632,6 +638,7 @@ mod tests {
             "1.2.3",
             &dto,
             &[],
+            &[],
             &extra,
             &caps,
             &adapters,
@@ -694,6 +701,7 @@ mod tests {
             "1.2.3",
             &dto,
             &[],
+            &[],
             &extra,
             &caps,
             &adapters,
@@ -739,6 +747,7 @@ mod tests {
             "_mod",
             "1.2.3",
             &dto,
+            &[],
             &[],
             &extra,
             &caps,

--- a/src/backends/pyo3/gen_bindings/functions/converters.rs
+++ b/src/backends/pyo3/gen_bindings/functions/converters.rs
@@ -14,7 +14,10 @@ pub(super) fn emit_converters(
     enum_names: &AHashSet<&str>,
     data_enum_names: &AHashSet<&str>,
     dto: &DtoConfig,
+    reexported_types: &[String],
 ) {
+    let output_style = dto.python_output_style();
+    let reexported_names: AHashSet<&str> = reexported_types.iter().map(|s| s.as_str()).collect();
     // Emit a helper that coerces strings or PyO3 enum aliases into the
     // canonical enum class instance. PyO3 enums do not expose a `__new__`
     // that accepts strings, so the wrapper must do the lookup itself.
@@ -31,11 +34,15 @@ pub(super) fn emit_converters(
         let typ = default_types[type_name];
         let snake = type_name.to_snake_case();
 
-        // `_to_rust_*` converters handle INPUT types (has_default config structs). These are
-        // typed according to the INPUT style (`dto.python`), NOT the output style. Use
-        // `value.get("field")` dict access only when the input style is TypedDict; otherwise
-        // use `value.field` attribute access (safe for dataclasses/pydantic).
-        let is_typeddict = dto.python == PythonDtoStyle::TypedDict;
+        // `_to_rust_*` converters handle has_default config structs. A type is emitted as a
+        // TypedDict (a dict at runtime, requiring `value.get("field")` access) only when it is a
+        // return type under the structural output style and is NOT re-exported as a native
+        // pyclass. This mirrors `gen_typeddict` in types.rs and the `options_type_names`
+        // classification in orchestration.rs. Pure input configs (e.g. ChunkingConfig) are
+        // always emitted as @dataclass, so they keep `value.field` attribute access.
+        let is_typeddict = output_style == PythonDtoStyle::TypedDict
+            && typ.is_return_type
+            && !reexported_names.contains(type_name.as_str());
 
         // Helper: emit `value.field` or `value.get("field")` depending on the type kind.
         let field_access = |name: &str| -> String {

--- a/src/backends/pyo3/gen_bindings/functions/converters.rs
+++ b/src/backends/pyo3/gen_bindings/functions/converters.rs
@@ -363,6 +363,16 @@ pub(super) fn emit_converters(
         } else {
             out.push_str("        return None\n");
         }
+        // TypedDict configs (total=False) carry only the keys the caller set, so reading every
+        // field with `value.get(...)` would pass `None` for omitted keys and the PyO3 constructor
+        // rejects `None` for non-Optional fields. The dict branch above already coerced nested
+        // structs/enums in place, so splat the present keys and let PyO3 apply its own defaults
+        // for the rest. (Skip when a visitor bridge needs an explicit override kwarg.)
+        if is_typeddict && bridge_visitor_field.is_none() {
+            out.push_str("    value = cast(dict[str, Any], value)\n");
+            out.push_str(&format!("    return _rust.{type_name}(**value)\n\n\n"));
+            continue;
+        }
         // Narrow `value` to the concrete dataclass for mypy. The signature accepts
         // `{type_name} | dict[str, Any] | str | None` so callers may pass JSON
         // strings or raw dicts, but by this point the str/dict branches above

--- a/src/backends/pyo3/gen_bindings/functions/converters.rs
+++ b/src/backends/pyo3/gen_bindings/functions/converters.rs
@@ -6,6 +6,7 @@ use heck::ToSnakeCase;
 
 type OptionsFieldBridges<'a> = AHashMap<&'a str, (&'a str, &'a str, Option<&'a str>)>;
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn emit_converters(
     out: &mut String,
     needed_converters: &[String],

--- a/src/backends/pyo3/gen_bindings/functions/orchestration.rs
+++ b/src/backends/pyo3/gen_bindings/functions/orchestration.rs
@@ -410,6 +410,7 @@ pub(in crate::backends::pyo3::gen_bindings) fn gen_api_py(
         &enum_names,
         &data_enum_names,
         dto,
+        reexported_types,
     );
 
     emit_function_wrappers(

--- a/src/backends/pyo3/gen_bindings/functions/orchestration.rs
+++ b/src/backends/pyo3/gen_bindings/functions/orchestration.rs
@@ -253,10 +253,25 @@ pub(in crate::backends::pyo3::gen_bindings) fn gen_api_py(
     // that the type leaves through the native return surface, and falsely excluding it from
     // .options is what produced alef#72 (PackConfig/ProcessConfig imported from ._native
     // despite being dataclasses re-exported from .options).
+    // Types re-exported in the public package as native pyclasses (config `reexported_types`):
+    // skip _rust. qualification for these.
+    let reexported_names: AHashSet<&str> = reexported_types.iter().map(|s| s.as_str()).collect();
+    let output_style = dto.python_output_style();
+    // A has_default struct lives in options.py (a config the caller constructs) unless it is a
+    // native return type. Under the structural (TypedDict) style only the curated `reexported_types`
+    // results stay native; a type that is `is_return_type` but not reexported (e.g. `ExtractionConfig`,
+    // returned by a resolver yet built by the caller) keeps its config identity and is imported from
+    // .options. Under the non-structural style every `is_return_type` lives in the native module.
     let options_type_names: AHashSet<String> = api
         .types
         .iter()
-        .filter(|t| t.has_default && !t.name.ends_with("Update") && !t.is_return_type)
+        .filter(|t| {
+            t.has_default
+                && !t.name.ends_with("Update")
+                && !(t.is_return_type
+                    && (output_style != crate::core::config::PythonDtoStyle::TypedDict
+                        || reexported_names.contains(t.name.as_str())))
+        })
         .map(|t| t.name.clone())
         .collect();
     // Types returned directly by free functions — these live in the native module,
@@ -268,8 +283,6 @@ pub(in crate::backends::pyo3::gen_bindings) fn gen_api_py(
         .filter(|t| t.is_return_type)
         .map(|t| t.name.clone())
         .collect();
-    // Types re-exported in the public package: skip _rust. qualification for these
-    let reexported_names: AHashSet<&str> = reexported_types.iter().map(|s| s.as_str()).collect();
     // All non-enum IR type names (used to distinguish structs from enums in classification).
     let all_ir_type_names: AHashSet<String> = api.types.iter().map(|t| t.name.clone()).collect();
     // Enums that options.py actually exports: plain (non-data) unit enums referenced by

--- a/src/backends/pyo3/gen_bindings/public_files.rs
+++ b/src/backends/pyo3/gen_bindings/public_files.rs
@@ -120,6 +120,7 @@ pub(super) fn generate_public_api(
         &module_name,
         &api.version,
         &config.dto,
+        &reexported_types,
         &config.trait_bridges,
         &extra_init_imports,
         &capsule_types,

--- a/tests/backends_pyo3_gen_bindings/options_exports.rs
+++ b/tests/backends_pyo3_gen_bindings/options_exports.rs
@@ -461,3 +461,147 @@ fn test_api_py_imports_config_dto_with_self_returning_method_from_options() {
         api_py.content
     );
 }
+
+/// Under the structural (TypedDict) output style, a result type listed in `reexported_types`
+/// must still be re-exported from the native module (an attribute-access pyclass matching the
+/// runtime object), while a type that is `is_return_type` but NOT reexported — e.g. a config a
+/// resolver returns yet callers construct, like `ExtractionConfig` — stays a structural
+/// `.options` type. Regression for kreuzberg-dev/alef#134 (public API didn't type-check).
+#[test]
+fn test_typeddict_style_reexports_only_listed_results_as_native() {
+    fn mk_type(name: &str, is_return_type: bool) -> TypeDef {
+        TypeDef {
+            name: name.to_string(),
+            rust_path: format!("my_lib::{name}"),
+            original_rust_path: String::new(),
+            fields: vec![make_field("value", TypeRef::String, false)],
+            methods: vec![],
+            is_opaque: false,
+            is_clone: true,
+            is_copy: false,
+            is_trait: false,
+            has_default: true,
+            has_stripped_cfg_fields: false,
+            is_return_type,
+            serde_rename_all: None,
+            has_serde: false,
+            super_traits: vec![],
+            doc: String::new(),
+            cfg: None,
+            binding_excluded: false,
+            binding_exclusion_reason: None,
+            is_variant_wrapper: false,
+            has_lifetime_params: false,
+            version: Default::default(),
+        }
+    }
+
+    let backend = Pyo3Backend;
+    // DocResult: pure result, listed in reexported_types -> native pyclass.
+    // DocConfig: is_return_type (a resolver returns it) AND a param the caller builds, not
+    // reexported -> structural .options TypedDict.
+    let api = ApiSurface {
+        crate_name: "my_lib".to_string(),
+        version: "1.0.0".to_string(),
+        types: vec![mk_type("DocResult", true), mk_type("DocConfig", true)],
+        functions: vec![FunctionDef {
+            name: "extract".to_string(),
+            rust_path: "my_lib::extract".to_string(),
+            original_rust_path: String::new(),
+            params: vec![ParamDef {
+                name: "config".to_string(),
+                ty: TypeRef::Named("DocConfig".to_string()),
+                optional: false,
+                default: None,
+                sanitized: false,
+                typed_default: None,
+                is_ref: false,
+                is_mut: false,
+                newtype_wrapper: None,
+                original_type: None,
+                map_is_ahash: false,
+                map_key_is_cow: false,
+                vec_inner_is_ref: false,
+                map_is_btree: false,
+                core_wrapper: alef::core::ir::CoreWrapper::None,
+            }],
+            return_type: TypeRef::Named("DocResult".to_string()),
+            is_async: false,
+            error_type: None,
+            doc: "Extract a document.".to_string(),
+            cfg: None,
+            sanitized: false,
+            return_sanitized: false,
+            returns_ref: false,
+            returns_cow: false,
+            return_newtype_wrapper: None,
+            binding_excluded: false,
+            binding_exclusion_reason: None,
+            version: Default::default(),
+        }],
+        enums: vec![],
+        errors: vec![],
+        excluded_type_paths: ::std::collections::HashMap::new(),
+        excluded_trait_names: ::std::collections::HashSet::new(),
+        services: vec![],
+        handler_contracts: vec![],
+        unsupported_public_items: Vec::new(),
+    };
+
+    let mut config = make_config();
+    config.dto = alef::core::config::DtoConfig {
+        python: alef::core::config::PythonDtoStyle::TypedDict,
+        ..Default::default()
+    };
+    config.python = Some(PythonConfig {
+        module_name: Some("_my_lib".to_string()),
+        pip_name: None,
+        async_runtime: None,
+        stubs: Some(StubsConfig {
+            output: std::path::PathBuf::from("packages/python/my_lib"),
+            emit_docstrings: false,
+        }),
+        features: None,
+        serde_rename_all: None,
+        capsule_types: Default::default(),
+        release_gil: false,
+        exclude_functions: Vec::new(),
+        exclude_types: Vec::new(),
+        extra_dependencies: Default::default(),
+        pip_dependencies: Vec::new(),
+        sdist_include: Vec::new(),
+        scaffold_output: Default::default(),
+        rename_fields: Default::default(),
+        run_wrapper: None,
+        extra_lint_paths: Vec::new(),
+        extra_init_imports: std::collections::BTreeMap::new(),
+        reexported_types: vec!["DocResult".to_string()],
+    });
+
+    let files = backend
+        .generate_public_api(&api, &config)
+        .expect("generate_public_api failed");
+    let init_py = &files
+        .iter()
+        .find(|f| f.path.ends_with("__init__.py"))
+        .expect("__init__.py")
+        .content;
+
+    let native_line = init_py
+        .lines()
+        .find(|l| l.contains("from ._my_lib import"))
+        .unwrap_or("");
+    let options_line = init_py
+        .lines()
+        .find(|l| l.contains("from .options import"))
+        .unwrap_or("");
+
+    assert!(
+        native_line.contains("DocResult"),
+        "reexported result must be imported from the native module:\n{init_py}"
+    );
+    assert!(
+        options_line.contains("DocConfig") && !native_line.contains("DocConfig"),
+        "is_return_type-but-not-reexported config must come from .options, not native:\n{init_py}"
+    );
+}


### PR DESCRIPTION
## Problem

Under the structural (TypedDict) Python output style, result types were re-exported in `__init__.py` from `.options` as TypedDicts. But the generated entrypoints return the native pyclass at runtime (attribute access), so the public name disagreed with the runtime object — the public API didn't type-check:

- Building `kreuzberg.ExtractionConfig(...)` and passing it to `extract_file_sync(...)` was an arg-type error (param annotated as the private pyclass).
- Reading `result.content` was a "no attribute" error (`kreuzberg.ExtractionResult` resolved to the TypedDict).

(kreuzberg-dev/alef#134)

## Solution

Treat a type as a native return — re-exported from the native module and used for the api.py return/param resolution — when it is `is_return_type` **and** either the output style is non-structural **or** it is in the curated `reexported_types`.

- Non-TypedDict styles are unchanged (every `is_return_type` stays native).
- Under TypedDict style, the curated results (e.g. `ExtractionResult`) become native pyclasses, while a config that a resolver also returns (e.g. `ExtractionConfig`) stays a `.options` TypedDict the caller constructs.

The result: `ExtractionConfig` is the TypedDict you build, `ExtractionResult` is the pyclass you read attributes off, and `extract_*` accepts/returns them consistently.

Verified end-to-end with mypy against the regenerated kreuzberg public API (the three previously-broken operations now type-check). Regression test added for the TypedDict + reexported case; full pyo3 suite green.

Closes #134.