### PR TITLE
fix(extendr): cast wide-integer return values to match the R-facing signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **extendr: free functions returning wide integers now cast the return value to match the
+  R-facing signature.** The extendr type mapper rewrites `usize`/`u64`/`i64`/`isize` to `f64`
+  and `u8`/`u16`/`u32` to `i32`, and the wrapper signature is rendered through that mapper. The
+  return value was forwarded uncast, so the body (`Vec<usize>`) disagreed with the signature
+  (`Vec<f64>`) and the generated R crate failed to compile with E0308. Scalar, `Vec`, `Option`,
+  and `Option<Vec>` return shapes are now cast at the value site. The cast is gated strictly on
+  the extendr-only cast flags, so pyo3/napi/wasm output is unchanged. (#145,
+  `src/codegen/generators/functions.rs`)
+
 ## [0.26.8] - 2026-06-23
 
 ### Fixed

--- a/src/backends/extendr/gen_bindings/tests.rs
+++ b/src/backends/extendr/gen_bindings/tests.rs
@@ -107,4 +107,5 @@ fn make_api_surface() -> ApiSurface {
 }
 
 mod trait_bridge;
+mod wide_int_returns;
 mod wrappers;

--- a/src/backends/extendr/gen_bindings/tests/wide_int_returns.rs
+++ b/src/backends/extendr/gen_bindings/tests/wide_int_returns.rs
@@ -1,0 +1,92 @@
+//! Regression tests for issue #145: extendr free functions returning wide integers
+//! must cast the core-call result so the wrapper body matches the R-facing signature.
+//!
+//! The extendr mapper rewrites `usize`/`u64`/`i64`/`isize` → `f64` and `u8`/`u16`/`u32`
+//! → `i32`. The return signature is rendered through that mapper, so without an explicit
+//! cast the body (`Vec<usize>`) disagrees with the signature (`Vec<f64>`) and the generated
+//! R crate fails to compile with E0308.
+//!
+//! Fixtures are deliberately neutral (no real downstream names). The pyo3 regression at the
+//! bottom guards that backends NOT setting the cast flags emit unchanged output.
+
+use super::ExtendrBackend;
+use crate::codegen::generators::gen_function;
+use crate::core::ir::{FunctionDef, PrimitiveType, TypeRef};
+
+fn extendr_function(return_type: TypeRef) -> String {
+    let func = FunctionDef {
+        name: "wide_value".to_owned(),
+        rust_path: "sample_core::wide_value".to_owned(),
+        params: vec![],
+        return_type,
+        is_async: false,
+        error_type: None,
+        ..FunctionDef::default()
+    };
+    let backend = ExtendrBackend;
+    let cfg = ExtendrBackend::binding_config("sample_core", &[]);
+    let adapter_bodies = ahash::AHashMap::new();
+    let opaque_types = ahash::AHashSet::new();
+    gen_function(&func, &backend, &cfg, &adapter_bodies, &opaque_types)
+}
+
+#[test]
+fn extendr_scalar_usize_return_casts_to_f64() {
+    let out = extendr_function(TypeRef::Primitive(PrimitiveType::Usize));
+    assert!(out.contains("-> f64"), "signature should map usize → f64:\n{out}");
+    assert!(
+        out.contains(") as f64"),
+        "scalar return should be cast with `as f64`:\n{out}"
+    );
+}
+
+#[test]
+fn extendr_vec_usize_return_casts_each_element_to_f64() {
+    let out = extendr_function(TypeRef::Vec(Box::new(TypeRef::Primitive(PrimitiveType::Usize))));
+    assert!(
+        out.contains("-> Vec<f64>"),
+        "signature should map Vec<usize> → Vec<f64>:\n{out}"
+    );
+    assert!(
+        out.contains(".into_iter().map(|v| v as f64).collect::<Vec<f64>>()"),
+        "Vec return should cast each element to f64:\n{out}"
+    );
+}
+
+#[test]
+fn extendr_option_usize_return_maps_cast_to_f64() {
+    let out = extendr_function(TypeRef::Optional(Box::new(TypeRef::Primitive(PrimitiveType::Usize))));
+    assert!(
+        out.contains("-> Option<f64>"),
+        "signature should map Option<usize> → Option<f64>:\n{out}"
+    );
+    assert!(
+        out.contains(".map(|v| v as f64)"),
+        "Option return should map-cast the inner value to f64:\n{out}"
+    );
+}
+
+#[test]
+fn extendr_option_vec_usize_return_maps_nested_cast_to_f64() {
+    let out = extendr_function(TypeRef::Optional(Box::new(TypeRef::Vec(Box::new(TypeRef::Primitive(
+        PrimitiveType::Usize,
+    ))))));
+    assert!(
+        out.contains("-> Option<Vec<f64>>"),
+        "signature should map Option<Vec<usize>> → Option<Vec<f64>>:\n{out}"
+    );
+    assert!(
+        out.contains(".map(|xs| xs.into_iter().map(|v| v as f64).collect::<Vec<f64>>())"),
+        "Option<Vec> return should map-cast each inner element to f64:\n{out}"
+    );
+}
+
+#[test]
+fn extendr_u32_return_casts_to_i32() {
+    let out = extendr_function(TypeRef::Primitive(PrimitiveType::U32));
+    assert!(out.contains("-> i32"), "signature should map u32 → i32:\n{out}");
+    assert!(
+        out.contains(") as i32"),
+        "small-uint return should be cast with `as i32`:\n{out}"
+    );
+}

--- a/src/backends/pyo3/gen_bindings/functions/tests.rs
+++ b/src/backends/pyo3/gen_bindings/functions/tests.rs
@@ -105,3 +105,38 @@ fn async_pyo3_functions_place_bindings_inside_async_block() {
     //       let result = core_crate::function_name(&param_refs, &param_core).await...
     //   })
 }
+
+/// Regression guard for issue #145: the wide-integer return cast is gated on the extendr-only
+/// cast flags (`cast_large_ints_to_f64` / `cast_uints_to_i32`). pyo3 does not set them, so a
+/// `usize` return must stay `usize` with no `as f64` cast leaking into the body.
+#[test]
+fn pyo3_usize_return_is_not_cast_to_f64() {
+    use crate::codegen::generators::gen_function;
+    use crate::core::ir::{FunctionDef, PrimitiveType};
+
+    let func = FunctionDef {
+        name: "wide_value".to_owned(),
+        rust_path: "sample_core::wide_value".to_owned(),
+        params: vec![],
+        return_type: TypeRef::Primitive(PrimitiveType::Usize),
+        is_async: false,
+        error_type: None,
+        ..FunctionDef::default()
+    };
+
+    let mapper = crate::backends::pyo3::type_map::Pyo3Mapper::new();
+    let cfg = crate::backends::pyo3::gen_bindings::config::binding_config("sample_core", true);
+    let adapter_bodies = ahash::AHashMap::new();
+    let opaque_types = ahash::AHashSet::new();
+
+    let output = gen_function(&func, &mapper, &cfg, &adapter_bodies, &opaque_types);
+
+    assert!(
+        !output.contains("as f64"),
+        "pyo3 usize return must not be cast to f64:\n{output}"
+    );
+    assert!(
+        output.contains("-> usize"),
+        "pyo3 signature should keep usize:\n{output}"
+    );
+}

--- a/src/codegen/generators/functions.rs
+++ b/src/codegen/generators/functions.rs
@@ -30,6 +30,80 @@ fn arc_wrap_expr(val: &str, name: &str, mutex_types: &AHashSet<String>) -> Strin
     }
 }
 
+/// Compute the cast target for a leaf primitive given the active wide-integer cast flags.
+///
+/// Mirrors the extendr type mapper: large ints (`usize`/`u64`/`i64`/`isize`) map to `f64`
+/// when `cast_large_ints_to_f64` is set, and small unsigned ints (`u8`/`u16`/`u32`) map to
+/// `i32` when `cast_uints_to_i32` is set. Returns `None` for any primitive the mapper leaves
+/// unchanged, so backends that do not set these flags (pyo3/napi/wasm) never trigger a cast.
+fn wide_int_cast_target(
+    prim: &crate::core::ir::PrimitiveType,
+    cast_large_ints_to_f64: bool,
+    cast_uints_to_i32: bool,
+) -> Option<&'static str> {
+    use crate::core::ir::PrimitiveType;
+    match prim {
+        PrimitiveType::Usize | PrimitiveType::U64 | PrimitiveType::I64 | PrimitiveType::Isize
+            if cast_large_ints_to_f64 =>
+        {
+            Some("f64")
+        }
+        PrimitiveType::U8 | PrimitiveType::U16 | PrimitiveType::U32 if cast_uints_to_i32 => Some("i32"),
+        _ => None,
+    }
+}
+
+/// When a wide-integer cast flag rewrites the return type's leaf primitive to a different
+/// R-representable type, cast the core-call result so the wrapper body matches the rendered
+/// signature (e.g. body yields `Vec<usize>` but the signature says `Vec<f64>`).
+///
+/// Returns `None` when no cast is needed (no flags set, or the primitive is left unchanged by
+/// the mapper). Handles the four shapes the mapper can rewrite: scalar `P`, `Vec<P>`,
+/// `Option<P>`, and `Option<Vec<P>>`. `expr` must already be the unwrapped value (the `Ok`
+/// payload / awaited value), never a `Result` or a serialized `String`.
+fn cast_return_expr(
+    ret: &TypeRef,
+    expr: &str,
+    cast_large_ints_to_f64: bool,
+    cast_uints_to_i32: bool,
+) -> Option<String> {
+    if !cast_large_ints_to_f64 && !cast_uints_to_i32 {
+        return None;
+    }
+    match ret {
+        TypeRef::Primitive(prim) => {
+            let target = wide_int_cast_target(prim, cast_large_ints_to_f64, cast_uints_to_i32)?;
+            Some(format!("({expr}) as {target}"))
+        }
+        TypeRef::Vec(inner) => {
+            let TypeRef::Primitive(prim) = inner.as_ref() else {
+                return None;
+            };
+            let target = wide_int_cast_target(prim, cast_large_ints_to_f64, cast_uints_to_i32)?;
+            Some(format!(
+                "{expr}.into_iter().map(|v| v as {target}).collect::<Vec<{target}>>()"
+            ))
+        }
+        TypeRef::Optional(inner) => match inner.as_ref() {
+            TypeRef::Primitive(prim) => {
+                let target = wide_int_cast_target(prim, cast_large_ints_to_f64, cast_uints_to_i32)?;
+                Some(format!("{expr}.map(|v| v as {target})"))
+            }
+            TypeRef::Vec(vinner) => {
+                let TypeRef::Primitive(prim) = vinner.as_ref() else {
+                    return None;
+                };
+                let target = wide_int_cast_target(prim, cast_large_ints_to_f64, cast_uints_to_i32)?;
+                Some(format!(
+                    "{expr}.map(|xs| xs.into_iter().map(|v| v as {target}).collect::<Vec<{target}>>())"
+                ))
+            }
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 /// Generate a free function. Equivalent to `gen_function_with_mutex` with no mutex types.
 pub fn gen_function(
     func: &FunctionDef,
@@ -242,6 +316,17 @@ pub fn gen_function_with_mutex(
             // Determine return wrapping strategy for serde async (uses explicit types to avoid E0283)
             let returns_ref = func.returns_ref;
             let wrap_return = |expr: &str| -> String {
+                // Cast wide-integer leaf primitives (extendr: usize/u64/i64/isize → f64,
+                // u8/u16/u32 → i32) so the value matches the rendered signature. No-op for
+                // backends without the cast flags; the unwrapped value is cast, never the Result.
+                if let Some(cast) = cast_return_expr(
+                    &func.return_type,
+                    expr,
+                    cfg.cast_large_ints_to_f64,
+                    cfg.cast_uints_to_i32,
+                ) {
+                    return cast;
+                }
                 match &func.return_type {
                     TypeRef::Vec(inner) => {
                         // Vec<T>: check if elements need conversion
@@ -384,15 +469,30 @@ pub fn gen_function_with_mutex(
                 _ => "result".to_string(),
             },
             TypeRef::Unit => "result".to_string(),
-            _ => super::binding_helpers::wrap_return(
-                "result",
-                &func.return_type,
-                "",
-                opaque_types,
-                false,
-                func.returns_ref,
-                false,
-            ),
+            _ => {
+                // Cast wide-integer leaf primitives (extendr: usize/u64/i64/isize → f64,
+                // u8/u16/u32 → i32) so the awaited value matches the rendered signature.
+                // No-op for backends that do not set the cast flags. The shared helper handles
+                // scalar/Vec/Option/Option<Vec> shapes; everything else passes through
+                // binding_helpers::wrap_return unchanged.
+                let cast = cast_return_expr(
+                    &func.return_type,
+                    "result",
+                    cfg.cast_large_ints_to_f64,
+                    cfg.cast_uints_to_i32,
+                );
+                cast.unwrap_or_else(|| {
+                    super::binding_helpers::wrap_return(
+                        "result",
+                        &func.return_type,
+                        "",
+                        opaque_types,
+                        false,
+                        func.returns_ref,
+                        false,
+                    )
+                })
+            }
         };
 
         // For Pyo3 async functions with let_bindings that create temporary borrows,
@@ -445,31 +545,20 @@ pub fn gen_function_with_mutex(
         // the GIL (no-op for other backends).
         let core_call = detach_core_call(&format!("{core_fn_path}({call_args})"));
 
-        // Check if we need to cast primitives due to type mapping (e.g., u32 → i32 for extendr)
-        let cast_suffix = match &func.return_type {
-            TypeRef::Primitive(prim) => {
-                let mapped = mapper.map_type(&func.return_type);
-                // If the mapped type differs from the original, we need a cast
-                let original = match prim {
-                    crate::core::ir::PrimitiveType::U8 => "u8",
-                    crate::core::ir::PrimitiveType::U16 => "u16",
-                    crate::core::ir::PrimitiveType::U32 => "u32",
-                    crate::core::ir::PrimitiveType::U64 => "u64",
-                    crate::core::ir::PrimitiveType::I8 => "i8",
-                    crate::core::ir::PrimitiveType::I16 => "i16",
-                    crate::core::ir::PrimitiveType::I32 => "i32",
-                    crate::core::ir::PrimitiveType::I64 => "i64",
-                    crate::core::ir::PrimitiveType::Usize => "usize",
-                    crate::core::ir::PrimitiveType::Isize => "isize",
-                    _ => "",
-                };
-                if !original.is_empty() && mapped != original {
-                    format!(" as {}", mapped)
-                } else {
-                    String::new()
-                }
-            }
-            _ => String::new(),
+        // When a wide-integer cast flag rewrites the return type's leaf primitive (extendr maps
+        // usize/u64/i64/isize → f64 and u8/u16/u32 → i32), cast the core-call value so the body
+        // matches the rendered signature. `cast_value` casts the unwrapped value expression
+        // (scalar / Vec / Option / Option<Vec> shapes); it is a no-op for backends that do not
+        // set the flags. Applied to the `Ok` payload in the Result path and to the bare value
+        // otherwise — never to a Result or serialized String.
+        let cast_value = |expr: &str| -> String {
+            cast_return_expr(
+                &func.return_type,
+                expr,
+                cfg.cast_large_ints_to_f64,
+                cfg.cast_uints_to_i32,
+            )
+            .unwrap_or_else(|| expr.to_string())
         };
 
         // Determine return wrapping strategy
@@ -616,33 +705,25 @@ pub fn gen_function_with_mutex(
                 _ => ".map_err(|e| e.to_string())",
             };
             let wrapped = wrap_return("val");
+            // Cast the `Ok` payload first; wide-int return shapes (scalar/Vec/Option primitives)
+            // make `wrap_return("val") == "val"`, so the cast IS the wrapped value.
+            let cast_val = cast_value("val");
             if wrapped == "val" {
-                if cast_suffix.is_empty() {
+                if cast_val == "val" {
                     format!("{core_call}{err_conv}")
                 } else {
-                    format!("{core_call}.map(|val| val{cast_suffix}){err_conv}")
+                    format!("{core_call}.map(|val| {cast_val}){err_conv}")
                 }
             } else if wrapped == "val.into()" {
-                if cast_suffix.is_empty() {
-                    format!("{core_call}.map(Into::into){err_conv}")
-                } else {
-                    format!("{core_call}.map(|val| (val{cast_suffix}).into()){err_conv}")
-                }
+                format!("{core_call}.map(Into::into){err_conv}")
             } else if let Some(type_path) = wrapped.strip_suffix("::from(val)") {
-                if cast_suffix.is_empty() {
-                    format!("{core_call}.map({type_path}::from){err_conv}")
-                } else {
-                    format!("{core_call}.map(|val| {type_path}::from(val{cast_suffix})){err_conv}")
-                }
+                format!("{core_call}.map({type_path}::from){err_conv}")
             } else {
                 format!("{core_call}.map(|val| {wrapped}){err_conv}")
             }
         } else {
-            if cast_suffix.is_empty() {
-                wrap_return(&core_call)
-            } else {
-                wrap_return(&format!("({core_call}){cast_suffix}"))
-            }
+            let cast = cast_value(&core_call);
+            wrap_return(&cast)
         }
     };
 


### PR DESCRIPTION
## Problem

The extendr backend maps wide integer return types to R-representable types in the generated `#[extendr]` wrapper signature — `usize`/`u64`/`i64`/`isize` to `f64`, and `u8`/`u16`/`u32` to `i32` — because R has no native integer of those widths. Parameters of these types are already cast in the body, but the native free-function path forwarded the core result **without** casting, so the wrapper signature and body disagreed and the R crate failed to compile.

Regenerating kreuzberg's R binding produced:

```
error[E0308]: mismatched types
   | pub fn find_inference_markers(markdown: String) -> Vec<f64> {
   |     kreuzberg::find_inference_markers(&markdown)
   |     ^^^ expected `Vec<f64>`, found `Vec<usize>`
```

Found while regenerating kreuzberg's bindings to validate separate work.

## Solution

In the shared free-function generator (`gen_function`), cast the unwrapped core-call value to match the rendered signature when — and only when — a wide-integer cast flag is set and the leaf primitive is one the mapper remaps. A small `cast_return_expr` helper handles the four shapes the mapper can rewrite: scalar `P`, `Vec<P>`, `Option<P>`, and `Option<Vec<P>>`, applied at the three value-construction sites (sync, async-delegate, serde).

The cast is gated strictly on `cfg.cast_large_ints_to_f64` / `cfg.cast_uints_to_i32`, which only the extendr backend sets, so pyo3/napi/wasm output is byte-identical (a pyo3 regression test asserts a `usize` return stays `-> usize`, uncast).

Verified end to end: regenerating kreuzberg's R binding against this branch, the `kreuzberg-r` crate now compiles — the `find_inference_markers` mismatch is gone.

Closes #145.
