### PR TITLE
fix(pyo3): coerce public dataclass/dict payloads in data-enum variant constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **pyo3 (Python): enum-variant payloads accept the public dataclass/dict.** A data-enum
+  per-variant constructor (e.g. `EmbeddingModelType.llm(...)`) now coerces a config-DTO payload the
+  same way struct fields are coerced, so passing the public `LlmConfig` dataclass — or a plain
+  `dict` — builds the variant instead of raising `TypeError: 'LlmConfig' object is not an instance
+  of 'LlmConfig'`. Previously the generated factory demanded the compiled `#[pyclass]` instance
+  while the package re-exported the pure-Python `@dataclass` for the same name, so the two never
+  matched. A payload field whose `Named` type is a dataclass-backed config DTO is now generated as
+  `&Bound<PyAny>` and routed through a module-level `__alef_coerce_dto` helper
+  (dataclass via `dataclasses.asdict` / dict / JSON-native → serde into the core type); native
+  re-exported return types stay compiled and are left untouched. The config-vs-native-return
+  classification is shared with `__init__.py` import routing as a single source of truth (xberg #1165).
+
 ## [0.28.1] - 2026-06-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `dict` — builds the variant instead of raising `TypeError: 'LlmConfig' object is not an instance
   of 'LlmConfig'`. Previously the generated factory demanded the compiled `#[pyclass]` instance
   while the package re-exported the pure-Python `@dataclass` for the same name, so the two never
-  matched. A payload field whose `Named` type is a dataclass-backed config DTO is now generated as
-  `&Bound<PyAny>` and routed through a module-level `__alef_coerce_dto` helper
-  (dataclass via `dataclasses.asdict` / dict / JSON-native → serde into the core type); native
-  re-exported return types stay compiled and are left untouched. The config-vs-native-return
-  classification is shared with `__init__.py` import routing as a single source of truth (xberg #1165).
+  matched. A payload field whose type is a dataclass-backed config DTO — directly, or as a
+  `list`/`dict`/`Optional` of one — is now generated as `&Bound<PyAny>` and routed through the
+  module-level `__alef_coerce_dto` helpers (dataclass via `dataclasses.asdict` / dict / JSON-native
+  → serde into the core type). Renamed fields round-trip with full fidelity: a per-DTO
+  `__ALEF_WIRE_*` schema rewrites dataclass field names to serde wire names, honoring both
+  `#[serde(rename)]` and `#[serde(rename_all)]` and recursing through nested DTOs, sequences, maps,
+  and optionals — wire names are sourced from the same centralized naming transform the Python
+  `_to_rust_*` converters use. Native re-exported return types stay compiled and are left untouched;
+  the config-vs-native-return classification is shared with `__init__.py` import routing as a single
+  source of truth (xberg #1165).
 
 ## [0.28.1] - 2026-06-25
 

--- a/src/backends/pyo3/gen_bindings/errors.rs
+++ b/src/backends/pyo3/gen_bindings/errors.rs
@@ -4,8 +4,36 @@ use crate::codegen::generators;
 use crate::codegen::shared::binding_fields;
 use crate::core::config::{DtoConfig, PythonDtoStyle};
 use crate::core::hash::{self, CommentStyle};
-use crate::core::ir::ApiSurface;
+use crate::core::ir::{ApiSurface, TypeDef};
 use ahash::AHashSet;
+
+/// True when `typ` is rendered as a pure-Python dataclass / TypedDict in `options.py` rather than
+/// being re-exported from the native module. For such types the public name resolves to the
+/// wrapper (a `@dataclass` or a plain `dict`), NOT the compiled `#[pyclass]`. This is the single
+/// source of truth for the config-vs-native-return split: `gen_init_py` uses it to route imports,
+/// and the data-enum variant-constructor generator uses it to decide which `Named` payload fields
+/// must be coerced (a native-return type stays compiled, so no coercion is needed or wanted).
+pub(super) fn is_dataclass_backed_config(
+    typ: &TypeDef,
+    output_style: PythonDtoStyle,
+    reexported_names: &AHashSet<&str>,
+) -> bool {
+    if typ.is_trait || typ.binding_excluded {
+        return false;
+    }
+    if typ.name.ends_with("Builder") || typ.name.ends_with("Update") {
+        return false;
+    }
+    if !typ.has_default || typ.fields.is_empty() {
+        return false;
+    }
+    // A `has_default` type that is also a return type is handed back to callers as an
+    // attribute-access pyclass and re-exported from the native module (unless the structural
+    // TypedDict style applies and it is not in `reexported_types`).
+    let is_native_return = typ.is_return_type
+        && (output_style != PythonDtoStyle::TypedDict || reexported_names.contains(typ.name.as_str()));
+    !is_native_return
+}
 
 fn render_relative_import(module_name: &str, imports: &[String]) -> String {
     crate::backends::pyo3::template_env::render(
@@ -148,12 +176,10 @@ pub(super) fn gen_init_py(
             continue;
         }
         if typ.has_default && !typ.name.ends_with("Update") && !typ.fields.is_empty() {
-            let is_native_return = typ.is_return_type
-                && (output_style != PythonDtoStyle::TypedDict || reexported_names.contains(typ.name.as_str()));
-            if is_native_return {
-                native_return_types.push(typ.name.clone());
-            } else {
+            if is_dataclass_backed_config(typ, output_style, &reexported_names) {
                 config_types.push(typ.name.clone());
+            } else {
+                native_return_types.push(typ.name.clone());
             }
             // Collect enum references regardless of whether the type is a return type or config
             // type — some enums are shared across both categories.

--- a/src/backends/pyo3/gen_bindings/mod.rs
+++ b/src/backends/pyo3/gen_bindings/mod.rs
@@ -602,6 +602,34 @@ impl Backend for Pyo3Backend {
             opaque_types.is_empty(),
         );
 
+        // Classify which config-DTO types are dataclass-backed: their public name resolves to a
+        // `@dataclass`/`dict` (via options.py), not the compiled `#[pyclass]`. Enum-variant payload
+        // fields of these types must accept the public wrapper or a dict — coerced into the core
+        // type — for parity with struct-field `_to_rust_*` coercion. Native-return types stay
+        // compiled and are left untouched. Same source of truth as `gen_init_py`'s import routing.
+        let dto_output_style = config.dto.python_output_style();
+        let reexported_dto_names: ahash::AHashSet<&str> = config
+            .python
+            .as_ref()
+            .map(|p| p.reexported_types.iter().map(String::as_str).collect())
+            .unwrap_or_default();
+        let coercible_dto_names: ahash::AHashSet<&str> = api
+            .types
+            .iter()
+            .filter(|t| errors::is_dataclass_backed_config(t, dto_output_style, &reexported_dto_names))
+            .map(|t| t.name.as_str())
+            .collect();
+        // Emit the runtime coercion helper once when any data-enum variant constructor needs it
+        // (gated on serde availability — the helper deserializes the coerced JSON into the core type).
+        if has_serde
+            && api
+                .enums
+                .iter()
+                .any(|e| generators::data_enum_needs_dto_coercion(e, &coercible_dto_names))
+        {
+            builder.add_item(generators::PYO3_DTO_COERCE_HELPER);
+        }
+
         for e in &api.enums {
             if generators::enum_has_data_variants(e) {
                 // Emit a `#[staticmethod]` constructor for each data-carrying struct variant
@@ -609,7 +637,8 @@ impl Backend for Pyo3Backend {
                 // idiomatic path — the discriminator is carried by the variant name rather than a
                 // magic `type="..."` string. The `#[new]` dict/kwargs/string constructor stays as-is
                 // for flexibility; the variant constructors are additive.
-                let data_enum_code = generators::gen_pyo3_data_enum_with_mapper(e, &core_import, Some(&mapper));
+                let data_enum_code =
+                    generators::gen_pyo3_data_enum_with_coercion(e, &core_import, Some(&mapper), &coercible_dto_names);
                 // A data enum is rendered as an opaque `{ inner: CoreEnum }` wrapper. The renderer
                 // already emits `impl Default` when the core enum's `has_default` is set. When a
                 // `Default`-deriving parent struct holds the enum as a non-optional field (tracked

--- a/src/backends/pyo3/gen_bindings/mod.rs
+++ b/src/backends/pyo3/gen_bindings/mod.rs
@@ -603,38 +603,15 @@ impl Backend for Pyo3Backend {
             opaque_types.is_empty(),
         );
 
-        // Classify which config-DTO types are dataclass-backed: their public name resolves to a
-        // `@dataclass`/`dict` (via options.py), not the compiled `#[pyclass]`. Enum-variant payload
-        // fields of these types must accept the public wrapper or a dict — coerced into the core
-        // type — for parity with struct-field `_to_rust_*` coercion. Native-return types stay
-        // compiled and are left untouched. Same source of truth as `gen_init_py`'s import routing.
-        let dto_output_style = config.dto.python_output_style();
-        let reexported_dto_names: ahash::AHashSet<&str> = config
-            .python
-            .as_ref()
-            .map(|p| p.reexported_types.iter().map(String::as_str).collect())
-            .unwrap_or_default();
-        let coercible_dto_names: ahash::AHashSet<&str> = api
-            .types
-            .iter()
-            .filter(|t| errors::is_dataclass_backed_config(t, dto_output_style, &reexported_dto_names))
-            .map(|t| t.name.as_str())
-            .collect();
-        // Emit the runtime coercion helper once when any data-enum variant constructor needs it
-        // (gated on serde availability — the helper deserializes the coerced JSON into the core type),
-        // followed by the per-DTO `__ALEF_WIRE_*` rename-schema consts that give the helper full
-        // serde-rename fidelity (handling `#[serde(rename)]`/`#[serde(rename_all)]` and nesting).
-        if has_serde
-            && api
-                .enums
-                .iter()
-                .any(|e| generators::data_enum_needs_dto_coercion(e, &coercible_dto_names))
-        {
-            builder.add_item(generators::PYO3_DTO_COERCE_HELPER);
-            let wire_schema_consts = wire_schema::gen_wire_schema_consts(api, &coercible_dto_names);
-            if !wire_schema_consts.is_empty() {
-                builder.add_item(&wire_schema_consts);
-            }
+        // Classify which config-DTO types are dataclass-backed (their public name is a
+        // `@dataclass`/`dict`, not the compiled `#[pyclass]`) so enum-variant payloads of those
+        // types are coerced rather than required as compiled instances. Then emit the runtime
+        // coercion helper plus the per-DTO `__ALEF_WIRE_*` rename-schema consts (both live in
+        // `wire_schema`). `coercible_dto_names` is reused below to drive the variant constructors.
+        let coercible_dto_names = wire_schema::coercible_dto_names(api, config);
+        let coercion_section = wire_schema::emit_dto_coercion_section(api, has_serde, &coercible_dto_names);
+        if !coercion_section.is_empty() {
+            builder.add_item(&coercion_section);
         }
 
         for e in &api.enums {

--- a/src/backends/pyo3/gen_bindings/mod.rs
+++ b/src/backends/pyo3/gen_bindings/mod.rs
@@ -18,6 +18,7 @@ mod support_items;
 #[cfg(test)]
 mod tests;
 pub mod types;
+mod wire_schema;
 
 use crate::backends::pyo3::type_map::Pyo3Mapper;
 use crate::codegen::builder::RustFileBuilder;
@@ -620,7 +621,9 @@ impl Backend for Pyo3Backend {
             .map(|t| t.name.as_str())
             .collect();
         // Emit the runtime coercion helper once when any data-enum variant constructor needs it
-        // (gated on serde availability — the helper deserializes the coerced JSON into the core type).
+        // (gated on serde availability — the helper deserializes the coerced JSON into the core type),
+        // followed by the per-DTO `__ALEF_WIRE_*` rename-schema consts that give the helper full
+        // serde-rename fidelity (handling `#[serde(rename)]`/`#[serde(rename_all)]` and nesting).
         if has_serde
             && api
                 .enums
@@ -628,6 +631,10 @@ impl Backend for Pyo3Backend {
                 .any(|e| generators::data_enum_needs_dto_coercion(e, &coercible_dto_names))
         {
             builder.add_item(generators::PYO3_DTO_COERCE_HELPER);
+            let wire_schema_consts = wire_schema::gen_wire_schema_consts(api, &coercible_dto_names);
+            if !wire_schema_consts.is_empty() {
+                builder.add_item(&wire_schema_consts);
+            }
         }
 
         for e in &api.enums {

--- a/src/backends/pyo3/gen_bindings/wire_schema.rs
+++ b/src/backends/pyo3/gen_bindings/wire_schema.rs
@@ -9,13 +9,54 @@
 //! same single source of truth the Python `_to_rust_*` converters use) and recurses through nested
 //! DTOs, sequences, maps, and optionals so renamed fields at any depth survive the round-trip.
 
+use super::errors::is_dataclass_backed_config;
 use crate::codegen::generators::{
-    coercible_payload, collect_variant_constructors, enum_has_data_variants, pyo3_wire_schema_const_name,
+    PYO3_DTO_COERCE_HELPER, coercible_payload, collect_variant_constructors, data_enum_needs_dto_coercion,
+    enum_has_data_variants, pyo3_wire_schema_const_name,
 };
 use crate::codegen::naming::wire_field_name;
 use crate::codegen::shared::binding_fields;
+use crate::core::config::ResolvedCrateConfig;
 use crate::core::ir::{ApiSurface, TypeDef};
 use ahash::{AHashMap, AHashSet};
+
+/// Classify the dataclass-backed config-DTO type names: their public name resolves to a
+/// `@dataclass`/`dict` (via `options.py`), not the compiled `#[pyclass]`. Enum-variant payload
+/// fields of these types must accept the public wrapper or a dict — coerced into the core type —
+/// for parity with struct-field `_to_rust_*` coercion. Native-return types stay compiled and are
+/// left untouched. Same source of truth as `gen_init_py`'s import routing.
+pub(super) fn coercible_dto_names<'a>(api: &'a ApiSurface, config: &ResolvedCrateConfig) -> AHashSet<&'a str> {
+    let output_style = config.dto.python_output_style();
+    let reexported: AHashSet<&str> = config
+        .python
+        .as_ref()
+        .map(|p| p.reexported_types.iter().map(String::as_str).collect())
+        .unwrap_or_default();
+    api.types
+        .iter()
+        .filter(|t| is_dataclass_backed_config(t, output_style, &reexported))
+        .map(|t| t.name.as_str())
+        .collect()
+}
+
+/// Emit the data-enum DTO-coercion section for the generated pyo3 module: the runtime coercion
+/// helper ([`PYO3_DTO_COERCE_HELPER`]) followed by the per-DTO `__ALEF_WIRE_*` rename-schema consts.
+/// Returns an empty string when no data-enum variant constructor needs coercion (or `serde` is
+/// unavailable — the helper deserializes the coerced JSON into the core type). The helper and the
+/// schema consts are joined the same way `RustFileBuilder` joins items (`"\n\n"`), so emitting this
+/// as a single item is byte-identical to emitting them separately.
+pub(super) fn emit_dto_coercion_section(api: &ApiSurface, has_serde: bool, coercible: &AHashSet<&str>) -> String {
+    let needed = has_serde && api.enums.iter().any(|e| data_enum_needs_dto_coercion(e, coercible));
+    if !needed {
+        return String::new();
+    }
+    let schema_consts = gen_wire_schema_consts(api, coercible);
+    if schema_consts.is_empty() {
+        PYO3_DTO_COERCE_HELPER.to_string()
+    } else {
+        format!("{PYO3_DTO_COERCE_HELPER}\n\n{schema_consts}")
+    }
+}
 
 /// One emitted `__AlefAlias` row.
 struct AliasEntry {

--- a/src/backends/pyo3/gen_bindings/wire_schema.rs
+++ b/src/backends/pyo3/gen_bindings/wire_schema.rs
@@ -1,0 +1,164 @@
+//! Generation of `__ALEF_WIRE_*` rename-schema consts for data-enum payload DTO coercion.
+//!
+//! A data-enum per-variant constructor accepts a public payload (a `@dataclass` or a `dict`) for a
+//! config-DTO field and coerces it into the core type via the `__alef_coerce_dto` runtime helper
+//! (see [`crate::codegen::generators::PYO3_DTO_COERCE_HELPER`]). A `@dataclass` carries Rust field
+//! names, while serde deserializes by wire name, so the helper rewrites the keys using a per-DTO
+//! `&[__AlefAlias]` schema emitted here. The schema honors both `#[serde(rename)]` and
+//! `#[serde(rename_all)]` (sourced from the centralized [`crate::codegen::naming`] transforms — the
+//! same single source of truth the Python `_to_rust_*` converters use) and recurses through nested
+//! DTOs, sequences, maps, and optionals so renamed fields at any depth survive the round-trip.
+
+use crate::codegen::generators::{
+    coercible_payload, collect_variant_constructors, enum_has_data_variants, pyo3_wire_schema_const_name,
+};
+use crate::codegen::naming::wire_field_name;
+use crate::codegen::shared::binding_fields;
+use crate::core::ir::{ApiSurface, TypeDef};
+use ahash::{AHashMap, AHashSet};
+
+/// One emitted `__AlefAlias` row.
+struct AliasEntry {
+    rust: String,
+    wire: String,
+    kind: &'static str,
+    /// Nested schema const name, or `&[]` for a leaf (rename-only) field.
+    nested: String,
+}
+
+/// Emit the `__ALEF_WIRE_*` rename-schema consts for every coercible DTO reachable from a data-enum
+/// variant-constructor payload field (transitively through nested coercible DTO fields). Returns an
+/// empty string when no coercion is in play. Cyclic type graphs are broken at back-edges (the deeper
+/// occurrence references `&[]`) so the emitted consts never form a const-evaluation cycle.
+pub(super) fn gen_wire_schema_consts(api: &ApiSurface, coercible_dto_names: &AHashSet<&str>) -> String {
+    if coercible_dto_names.is_empty() {
+        return String::new();
+    }
+    let types: AHashMap<&str, &TypeDef> = api.types.iter().map(|t| (t.name.as_str(), t)).collect();
+
+    // Seed from every coercible Named/Optional(Named) payload field of a generated variant ctor.
+    let mut seeds: Vec<String> = Vec::new();
+    for e in &api.enums {
+        if !enum_has_data_variants(e) {
+            continue;
+        }
+        for ctor in collect_variant_constructors(e) {
+            for p in &ctor.params {
+                // Any coercible payload shape (a DTO, or a list/map of DTOs) needs its schema const.
+                if let Some((dto, _)) = coercible_payload(&p.ty, coercible_dto_names) {
+                    if !seeds.iter().any(|s| s == dto) {
+                        seeds.push(dto.to_string());
+                    }
+                }
+            }
+        }
+    }
+    if seeds.is_empty() {
+        return String::new();
+    }
+
+    // DFS building one const per reachable type, breaking cycles at back-edges.
+    let mut built: Vec<(String, Vec<AliasEntry>)> = Vec::new();
+    let mut done: AHashSet<String> = AHashSet::new();
+    for seed in &seeds {
+        build_type(
+            seed,
+            &types,
+            coercible_dto_names,
+            &mut Vec::new(),
+            &mut done,
+            &mut built,
+        );
+    }
+
+    // Deterministic output order.
+    built.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut out = String::new();
+    for (const_name, entries) in &built {
+        let rendered_entries: Vec<minijinja::Value> = entries
+            .iter()
+            .map(|e| {
+                minijinja::context! {
+                    rust => &e.rust,
+                    wire => &e.wire,
+                    kind => e.kind,
+                    nested => &e.nested,
+                }
+            })
+            .collect();
+        out.push_str(&crate::backends::pyo3::template_env::render(
+            "pyo3_wire_schema_const.jinja",
+            minijinja::context! {
+                const_name => const_name,
+                entries => rendered_entries,
+            },
+        ));
+        out.push('\n');
+    }
+    out
+}
+
+/// Build (and memoize) the schema const for `type_name`, recursing into nested coercible DTOs.
+/// `path` tracks the current DFS ancestry so a back-edge to a type still being built is broken
+/// (`&[]`) — guaranteeing the const-reference graph stays acyclic.
+fn build_type(
+    type_name: &str,
+    types: &AHashMap<&str, &TypeDef>,
+    coercible: &AHashSet<&str>,
+    path: &mut Vec<String>,
+    done: &mut AHashSet<String>,
+    built: &mut Vec<(String, Vec<AliasEntry>)>,
+) {
+    if done.contains(type_name) {
+        return;
+    }
+    let Some(typ) = types.get(type_name) else {
+        // No TypeDef (e.g. an opaque or externally-defined type): emit an empty schema so the
+        // referencing const still resolves.
+        done.insert(type_name.to_string());
+        built.push((pyo3_wire_schema_const_name(type_name), Vec::new()));
+        return;
+    };
+    done.insert(type_name.to_string());
+    path.push(type_name.to_string());
+
+    let rename_all = typ.serde_rename_all.as_deref();
+    let mut entries: Vec<AliasEntry> = Vec::new();
+    for field in binding_fields(&typ.fields) {
+        let wire = wire_field_name(&field.name, field.serde_rename.as_deref(), rename_all);
+        match coercible_payload(&field.ty, coercible) {
+            Some((dto_name, shape)) => {
+                // Break cycles: a back-edge to a type currently on the DFS path references `&[]`.
+                let nested = if path.iter().any(|p| p == dto_name) {
+                    "&[]".to_string()
+                } else {
+                    build_type(dto_name, types, coercible, path, done, built);
+                    pyo3_wire_schema_const_name(dto_name)
+                };
+                entries.push(AliasEntry {
+                    rust: field.name.clone(),
+                    wire,
+                    kind: shape.wire_kind(),
+                    nested,
+                });
+            }
+            None => {
+                // Leaf field: only needs an entry when its wire name differs from the Rust name.
+                if wire != field.name {
+                    entries.push(AliasEntry {
+                        rust: field.name.clone(),
+                        wire,
+                        kind: "Leaf",
+                        nested: "&[]".to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    path.pop();
+    built.push((pyo3_wire_schema_const_name(type_name), entries));
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/backends/pyo3/gen_bindings/wire_schema/tests.rs
+++ b/src/backends/pyo3/gen_bindings/wire_schema/tests.rs
@@ -1,0 +1,203 @@
+use super::gen_wire_schema_consts;
+use crate::core::ir::{ApiSurface, EnumDef, EnumVariant, FieldDef, TypeDef, TypeRef};
+use ahash::AHashSet;
+
+fn named_field(name: &str, type_name: &str) -> FieldDef {
+    FieldDef {
+        name: name.to_string(),
+        ty: TypeRef::Named(type_name.to_string()),
+        ..Default::default()
+    }
+}
+
+fn string_field(name: &str, serde_rename: Option<&str>) -> FieldDef {
+    FieldDef {
+        name: name.to_string(),
+        ty: TypeRef::String,
+        serde_rename: serde_rename.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+fn config_type(name: &str, rename_all: Option<&str>, fields: Vec<FieldDef>) -> TypeDef {
+    TypeDef {
+        name: name.to_string(),
+        rust_path: format!("crate::{name}"),
+        fields,
+        has_default: true,
+        has_serde: true,
+        serde_rename_all: rename_all.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+/// A data enum with one struct variant carrying the given config DTO as its payload — the seed for
+/// the reachability walk.
+fn enum_with_payload(field_type: &str) -> EnumDef {
+    EnumDef {
+        name: "ModelType".to_string(),
+        rust_path: "crate::ModelType".to_string(),
+        has_serde: true,
+        variants: vec![EnumVariant {
+            name: "Run".to_string(),
+            fields: vec![named_field("config", field_type)],
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+fn surface(types: Vec<TypeDef>, enums: Vec<EnumDef>) -> ApiSurface {
+    ApiSurface {
+        types,
+        enums,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn per_field_rename_is_carried_to_wire_name() {
+    let cfg = config_type(
+        "RunConfig",
+        None,
+        vec![string_field("max_chars", Some("maxCharacters"))],
+    );
+    let api = surface(vec![cfg], vec![enum_with_payload("RunConfig")]);
+    let coercible: AHashSet<&str> = ["RunConfig"].into_iter().collect();
+
+    let generated = gen_wire_schema_consts(&api, &coercible);
+
+    assert!(
+        generated.contains("const __ALEF_WIRE_RUN_CONFIG: &[__AlefAlias] = &["),
+        "{generated}"
+    );
+    assert!(
+        generated.contains(
+            r#"__AlefAlias { rust: "max_chars", wire: "maxCharacters", kind: __AlefKind::Leaf, nested: &[] }"#
+        ),
+        "{generated}"
+    );
+}
+
+#[test]
+fn struct_level_rename_all_is_applied_to_wire_names() {
+    // `rename_all = "camelCase"` is sourced from the centralized naming transform, not an ad-hoc
+    // casing path — `model_id` -> `modelId`. A field already matching its wire name (`region`) gets
+    // no entry.
+    let cfg = config_type(
+        "RunConfig",
+        Some("camelCase"),
+        vec![string_field("model_id", None), string_field("region", None)],
+    );
+    let api = surface(vec![cfg], vec![enum_with_payload("RunConfig")]);
+    let coercible: AHashSet<&str> = ["RunConfig"].into_iter().collect();
+
+    let generated = gen_wire_schema_consts(&api, &coercible);
+
+    assert!(
+        generated.contains(r#"__AlefAlias { rust: "model_id", wire: "modelId", kind: __AlefKind::Leaf, nested: &[] }"#),
+        "{generated}"
+    );
+    // `region` == its camelCase wire name, so it is omitted (no redundant entry).
+    assert!(!generated.contains(r#"rust: "region""#), "{generated}");
+}
+
+#[test]
+fn nested_dto_recurses_with_its_own_schema_const() {
+    // Outer holds a nested coercible DTO (`InnerConfig`) which itself has a renamed field. The outer
+    // schema references the inner schema const; both consts are emitted.
+    let inner = config_type("InnerConfig", None, vec![string_field("api_key", Some("apiKey"))]);
+    let outer = config_type("OuterConfig", None, vec![named_field("inner", "InnerConfig")]);
+    let api = surface(vec![outer, inner], vec![enum_with_payload("OuterConfig")]);
+    let coercible: AHashSet<&str> = ["OuterConfig", "InnerConfig"].into_iter().collect();
+
+    let generated = gen_wire_schema_consts(&api, &coercible);
+
+    assert!(
+        generated.contains(
+            r#"__AlefAlias { rust: "inner", wire: "inner", kind: __AlefKind::Object, nested: __ALEF_WIRE_INNER_CONFIG }"#
+        ),
+        "{generated}"
+    );
+    assert!(
+        generated.contains("const __ALEF_WIRE_INNER_CONFIG: &[__AlefAlias] = &["),
+        "{generated}"
+    );
+    assert!(
+        generated.contains(r#"__AlefAlias { rust: "api_key", wire: "apiKey", kind: __AlefKind::Leaf, nested: &[] }"#),
+        "{generated}"
+    );
+}
+
+#[test]
+fn vec_and_optional_of_dto_use_seq_kind() {
+    let item = config_type("ItemConfig", None, vec![string_field("item_id", Some("itemId"))]);
+    let outer = config_type(
+        "OuterConfig",
+        None,
+        vec![FieldDef {
+            name: "items".to_string(),
+            ty: TypeRef::Optional(Box::new(TypeRef::Vec(Box::new(TypeRef::Named(
+                "ItemConfig".to_string(),
+            ))))),
+            ..Default::default()
+        }],
+    );
+    let api = surface(vec![outer, item], vec![enum_with_payload("OuterConfig")]);
+    let coercible: AHashSet<&str> = ["OuterConfig", "ItemConfig"].into_iter().collect();
+
+    let generated = gen_wire_schema_consts(&api, &coercible);
+
+    assert!(
+        generated.contains(
+            r#"__AlefAlias { rust: "items", wire: "items", kind: __AlefKind::Seq, nested: __ALEF_WIRE_ITEM_CONFIG }"#
+        ),
+        "{generated}"
+    );
+}
+
+#[test]
+fn cyclic_type_graph_breaks_back_edge() {
+    // A self-referential config (`Node { child: Option<Node> }`) must not emit a const that
+    // references itself (which would be a const-eval cycle). The back-edge is broken to `&[]`.
+    let node = config_type(
+        "NodeConfig",
+        None,
+        vec![
+            string_field("node_name", Some("nodeName")),
+            FieldDef {
+                name: "child".to_string(),
+                ty: TypeRef::Optional(Box::new(TypeRef::Named("NodeConfig".to_string()))),
+                ..Default::default()
+            },
+        ],
+    );
+    let api = surface(vec![node], vec![enum_with_payload("NodeConfig")]);
+    let coercible: AHashSet<&str> = ["NodeConfig"].into_iter().collect();
+
+    let generated = gen_wire_schema_consts(&api, &coercible);
+
+    // Exactly one const, and the self-referential `child` edge is broken (nested: &[]), never
+    // referencing __ALEF_WIRE_NODE_CONFIG from within itself.
+    assert_eq!(
+        generated.matches("const __ALEF_WIRE_NODE_CONFIG:").count(),
+        1,
+        "{generated}"
+    );
+    assert!(
+        generated.contains(r#"__AlefAlias { rust: "child", wire: "child", kind: __AlefKind::Object, nested: &[] }"#),
+        "{generated}"
+    );
+    assert!(
+        generated
+            .contains(r#"__AlefAlias { rust: "node_name", wire: "nodeName", kind: __AlefKind::Leaf, nested: &[] }"#),
+        "{generated}"
+    );
+}
+
+#[test]
+fn no_coercible_types_emits_nothing() {
+    let api = surface(vec![], vec![]);
+    let coercible: AHashSet<&str> = AHashSet::new();
+    assert!(gen_wire_schema_consts(&api, &coercible).is_empty());
+}

--- a/src/backends/pyo3/template_env.rs
+++ b/src/backends/pyo3/template_env.rs
@@ -477,6 +477,10 @@ static TEMPLATES: &[(&str, &str)] = &[
         include_str!("templates/config_default_on_none.jinja"),
     ),
     (
+        "pyo3_wire_schema_const.jinja",
+        include_str!("templates/pyo3_wire_schema_const.jinja"),
+    ),
+    (
         "data_enum_dict_coerce_guard.jinja",
         include_str!("templates/data_enum_dict_coerce_guard.jinja"),
     ),

--- a/src/backends/pyo3/templates/pyo3_wire_schema_const.jinja
+++ b/src/backends/pyo3/templates/pyo3_wire_schema_const.jinja
@@ -1,0 +1,5 @@
+const {{ const_name }}: &[__AlefAlias] = &[
+{%- for e in entries %}
+    __AlefAlias { rust: "{{ e.rust }}", wire: "{{ e.wire }}", kind: __AlefKind::{{ e.kind }}, nested: {{ e.nested }} },
+{%- endfor %}
+];

--- a/src/codegen/generators/dto_coercion.rs
+++ b/src/codegen/generators/dto_coercion.rs
@@ -1,0 +1,222 @@
+//! Data-enum payload DTO coercion for the pyo3 backend.
+//!
+//! A data-enum per-variant constructor (e.g. `EmbeddingModelType.llm(...)`) accepts a public payload
+//! — a `@dataclass`, a `dict`, or a list/map of either — for a config-DTO field and coerces it into
+//! the core type, rather than demanding the compiled `#[pyclass]` instance. This module owns that
+//! concern end to end: the module-level runtime helper ([`PYO3_DTO_COERCE_HELPER`]), the classifier
+//! that decides which payload fields are coercible and in what shape ([`coercible_payload`] /
+//! [`CoercibleShape`]), the per-DTO rename-schema const naming ([`pyo3_wire_schema_const_name`]),
+//! and the per-field init expression the variant-constructor emitter splices in
+//! ([`coercible_field_init`]). The variant-constructor emission itself lives in [`super::enums`].
+
+use super::enums::{collect_variant_constructors, enum_has_data_variants};
+use crate::core::ir::{EnumDef, TypeRef};
+use ahash::AHashSet;
+
+/// Module-level runtime helper coercing a public payload (dataclass / dict / JSON-native value)
+/// into a core type via serde. Emitted once per pyo3 module when any data-enum variant constructor
+/// has a coercible config-DTO field. Mirrors the struct-field `_to_rust_*` coercion on the Python
+/// side so enum-variant payloads accept the same inputs (the public `LlmConfig` dataclass or a
+/// `dict`), instead of demanding the compiled `#[pyclass]` instance.
+///
+/// The helper is non-parameterized (this rule allows a static `const` for non-interpolated code).
+/// Per-DTO rename fidelity is supplied at the call site as a runtime `&[__AlefAlias]` schema (the
+/// `__ALEF_WIRE_*` module consts emitted by the pyo3 backend), so a dataclass whose fields use
+/// `#[serde(rename)]` or `#[serde(rename_all)]` — including nested DTOs, sequences, maps, and
+/// optionals — round-trips faithfully. Plain dicts already carry serde wire names and pass straight
+/// through without remapping.
+pub const PYO3_DTO_COERCE_HELPER: &str = r#"struct __AlefAlias {
+    rust: &'static str,
+    wire: &'static str,
+    kind: __AlefKind,
+    nested: &'static [__AlefAlias],
+}
+
+enum __AlefKind {
+    Leaf,
+    Object,
+    Seq,
+    Map,
+}
+
+fn __alef_apply_aliases(value: &mut serde_json::Value, aliases: &[__AlefAlias]) {
+    let serde_json::Value::Object(map) = value else {
+        return;
+    };
+    for alias in aliases {
+        if !alias.nested.is_empty() {
+            if let Some(child) = map.get_mut(alias.rust) {
+                match alias.kind {
+                    __AlefKind::Object => __alef_apply_aliases(child, alias.nested),
+                    __AlefKind::Seq => {
+                        if let serde_json::Value::Array(items) = child {
+                            for item in items.iter_mut() {
+                                __alef_apply_aliases(item, alias.nested);
+                            }
+                        }
+                    }
+                    __AlefKind::Map => {
+                        if let serde_json::Value::Object(entries) = child {
+                            for entry in entries.values_mut() {
+                                __alef_apply_aliases(entry, alias.nested);
+                            }
+                        }
+                    }
+                    __AlefKind::Leaf => {}
+                }
+            }
+        }
+        if alias.rust != alias.wire {
+            if let Some(taken) = map.remove(alias.rust) {
+                map.insert(alias.wire.to_string(), taken);
+            }
+        }
+    }
+}
+
+fn __alef_coerce_dto<T: serde::de::DeserializeOwned>(
+    py: Python<'_>,
+    value: &Bound<'_, pyo3::types::PyAny>,
+    aliases: &[__AlefAlias],
+) -> PyResult<T> {
+    // A public @dataclass is not directly JSON-serializable: convert it via `dataclasses.asdict`
+    // (which emits Rust field names) and rewrite the keys to serde wire names so renamed fields
+    // survive. A plain dict / JSON-native value already uses wire names and passes straight through.
+    if value.hasattr("__dataclass_fields__")? {
+        let as_dict = py.import("dataclasses")?.call_method1("asdict", (value,))?;
+        let json_str: String = py.import("json")?.call_method1("dumps", (as_dict,))?.extract()?;
+        let mut json_value: serde_json::Value =
+            serde_json::from_str(&json_str).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        __alef_apply_aliases(&mut json_value, aliases);
+        serde_json::from_value(json_value).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+    } else {
+        let json_str: String = py.import("json")?.call_method1("dumps", (value,))?.extract()?;
+        serde_json::from_str(&json_str).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+    }
+}
+
+fn __alef_coerce_dto_seq<T: serde::de::DeserializeOwned>(
+    py: Python<'_>,
+    value: &Bound<'_, pyo3::types::PyAny>,
+    aliases: &[__AlefAlias],
+) -> PyResult<Vec<T>> {
+    let items: Vec<Bound<'_, pyo3::types::PyAny>> = value.extract()?;
+    let mut out = Vec::with_capacity(items.len());
+    for item in &items {
+        out.push(__alef_coerce_dto(py, item, aliases)?);
+    }
+    Ok(out)
+}
+
+fn __alef_coerce_dto_map<T: serde::de::DeserializeOwned>(
+    py: Python<'_>,
+    value: &Bound<'_, pyo3::types::PyAny>,
+    aliases: &[__AlefAlias],
+) -> PyResult<T> {
+    // Build a wire-keyed JSON object from the mapping's items (each value coerced like a DTO via
+    // the object helper), then deserialize the whole map into the core type.
+    let items: Vec<(String, Bound<'_, pyo3::types::PyAny>)> = value.call_method0("items")?.extract()?;
+    let mut object = serde_json::Map::with_capacity(items.len());
+    for (key, val) in &items {
+        object.insert(key.clone(), __alef_coerce_dto(py, val, aliases)?);
+    }
+    serde_json::from_value(serde_json::Value::Object(object))
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+}"#;
+
+/// The module-const identifier holding the `&[__AlefAlias]` rename schema for a coercible DTO
+/// (`LlmConfig` → `__ALEF_WIRE_LLM_CONFIG`). Shared between the pyo3 backend (which emits the const)
+/// and the variant-constructor call site (which references it) so there is a single naming path.
+pub fn pyo3_wire_schema_const_name(type_name: &str) -> String {
+    use heck::ToShoutySnakeCase;
+    format!("__ALEF_WIRE_{}", type_name.to_shouty_snake_case())
+}
+
+/// The JSON shape a coercible payload field takes, selecting which runtime coercion helper the
+/// generated factory calls.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum CoercibleShape {
+    /// A single DTO (`Named` / `Optional<Named>`) → `__alef_coerce_dto`.
+    Object,
+    /// A list of DTOs (`Vec<Named>` / `Optional<Vec<Named>>`) → `__alef_coerce_dto_seq`.
+    Seq,
+    /// A string-keyed map of DTOs (`Map<_, Named>` / `Optional<Map<_, Named>>`) → `__alef_coerce_dto_map`.
+    Map,
+}
+
+impl CoercibleShape {
+    /// The `__AlefKind` variant name this shape recurses as in a `__ALEF_WIRE_*` rename schema.
+    pub fn wire_kind(self) -> &'static str {
+        match self {
+            CoercibleShape::Object => "Object",
+            CoercibleShape::Seq => "Seq",
+            CoercibleShape::Map => "Map",
+        }
+    }
+}
+
+/// Resolve the coercible config-DTO a variant payload field carries and the JSON shape of its value.
+/// `Optional` is transparent. Returns `None` when the field is not (or does not contain) a coercible
+/// DTO — those keep the compiled-instance `.into()` path. The returned `&str` is the DTO type name,
+/// used to select its `__ALEF_WIRE_*` rename schema. Single source of truth for both the
+/// variant-constructor call site and the pyo3 backend's rename-schema generation.
+pub fn coercible_payload<'a>(ty: &'a TypeRef, coercible: &AHashSet<&str>) -> Option<(&'a str, CoercibleShape)> {
+    let named_if_coercible = |t: &'a TypeRef| match t {
+        TypeRef::Named(n) if coercible.contains(n.as_str()) => Some(n.as_str()),
+        _ => None,
+    };
+    match ty {
+        TypeRef::Optional(inner) => coercible_payload(inner, coercible),
+        TypeRef::Vec(inner) => named_if_coercible(inner).map(|n| (n, CoercibleShape::Seq)),
+        TypeRef::Map(_, value) => named_if_coercible(value).map(|n| (n, CoercibleShape::Map)),
+        TypeRef::Named(_) => named_if_coercible(ty).map(|n| (n, CoercibleShape::Object)),
+        _ => None,
+    }
+}
+
+/// True when any generated variant constructor of `enum_def` has a coercible config-DTO payload
+/// field — i.e. the [`PYO3_DTO_COERCE_HELPER`] runtime helper must be emitted into the module.
+pub fn data_enum_needs_dto_coercion(enum_def: &EnumDef, coercible_dto_names: &AHashSet<&str>) -> bool {
+    if !enum_has_data_variants(enum_def) {
+        return false;
+    }
+    collect_variant_constructors(enum_def).iter().any(|c| {
+        c.params
+            .iter()
+            .any(|p| coercible_payload(&p.ty, coercible_dto_names).is_some())
+    })
+}
+
+/// Build the struct-literal init expression for a coercible config-DTO payload field. The param
+/// arrives as `&Bound<PyAny>` (or `Option<&Bound<PyAny>>` when optional/promoted) and is routed
+/// through the shape-appropriate `__alef_coerce_dto*` helper, whose target core type is resolved by
+/// inference from the variant literal slot — so the core type path is never named (non-re-exported
+/// core DTOs work unchanged). The `dto` type name selects the per-DTO `&[__AlefAlias]` rename schema
+/// const so the dataclass round-trips with full serde-rename fidelity (a `Seq`/`Map` field applies
+/// it to each element/value).
+///
+/// `promoted` is true when the binding signature widened a non-optional core field to `Option<T>`
+/// because it follows an optional param; the coerced value is unwrapped to the field default.
+pub(crate) fn coercible_field_init(
+    name: &str,
+    dto: &str,
+    shape: CoercibleShape,
+    optional: bool,
+    promoted: bool,
+) -> String {
+    let schema = pyo3_wire_schema_const_name(dto);
+    let helper = match shape {
+        CoercibleShape::Object => "__alef_coerce_dto",
+        CoercibleShape::Seq => "__alef_coerce_dto_seq",
+        CoercibleShape::Map => "__alef_coerce_dto_map",
+    };
+    if optional {
+        // Genuinely-optional core field: keep the `Option`, coercing the inner value when present.
+        format!("{name}.map(|v| {helper}(py, v, {schema})).transpose()?")
+    } else if promoted {
+        // Core field is `T` but the param arrived as `Option<&Bound>`: coerce then unwrap to default.
+        format!("{name}.map(|v| {helper}(py, v, {schema})).transpose()?.unwrap_or_default()")
+    } else {
+        format!("{helper}(py, {name}, {schema})?")
+    }
+}

--- a/src/codegen/generators/enums.rs
+++ b/src/codegen/generators/enums.rs
@@ -1,181 +1,8 @@
+use super::dto_coercion::{coercible_field_init, coercible_payload};
 use crate::codegen::generators::RustBindingConfig;
 use crate::codegen::type_mapper::TypeMapper;
 use crate::core::ir::{EnumDef, TypeRef};
 use ahash::AHashSet;
-
-/// Module-level runtime helper coercing a public payload (dataclass / dict / JSON-native value)
-/// into a core type via serde. Emitted once per pyo3 module when any data-enum variant constructor
-/// has a coercible config-DTO field. Mirrors the struct-field `_to_rust_*` coercion on the Python
-/// side so enum-variant payloads accept the same inputs (the public `LlmConfig` dataclass or a
-/// `dict`), instead of demanding the compiled `#[pyclass]` instance.
-///
-/// The helper is non-parameterized (this rule allows a static `const` for non-interpolated code).
-/// Per-DTO rename fidelity is supplied at the call site as a runtime `&[__AlefAlias]` schema (the
-/// `__ALEF_WIRE_*` module consts emitted by the pyo3 backend), so a dataclass whose fields use
-/// `#[serde(rename)]` or `#[serde(rename_all)]` — including nested DTOs, sequences, maps, and
-/// optionals — round-trips faithfully. Plain dicts already carry serde wire names and pass straight
-/// through without remapping.
-pub const PYO3_DTO_COERCE_HELPER: &str = r#"struct __AlefAlias {
-    rust: &'static str,
-    wire: &'static str,
-    kind: __AlefKind,
-    nested: &'static [__AlefAlias],
-}
-
-enum __AlefKind {
-    Leaf,
-    Object,
-    Seq,
-    Map,
-}
-
-fn __alef_apply_aliases(value: &mut serde_json::Value, aliases: &[__AlefAlias]) {
-    let serde_json::Value::Object(map) = value else {
-        return;
-    };
-    for alias in aliases {
-        if !alias.nested.is_empty() {
-            if let Some(child) = map.get_mut(alias.rust) {
-                match alias.kind {
-                    __AlefKind::Object => __alef_apply_aliases(child, alias.nested),
-                    __AlefKind::Seq => {
-                        if let serde_json::Value::Array(items) = child {
-                            for item in items.iter_mut() {
-                                __alef_apply_aliases(item, alias.nested);
-                            }
-                        }
-                    }
-                    __AlefKind::Map => {
-                        if let serde_json::Value::Object(entries) = child {
-                            for entry in entries.values_mut() {
-                                __alef_apply_aliases(entry, alias.nested);
-                            }
-                        }
-                    }
-                    __AlefKind::Leaf => {}
-                }
-            }
-        }
-        if alias.rust != alias.wire {
-            if let Some(taken) = map.remove(alias.rust) {
-                map.insert(alias.wire.to_string(), taken);
-            }
-        }
-    }
-}
-
-fn __alef_coerce_dto<T: serde::de::DeserializeOwned>(
-    py: Python<'_>,
-    value: &Bound<'_, pyo3::types::PyAny>,
-    aliases: &[__AlefAlias],
-) -> PyResult<T> {
-    // A public @dataclass is not directly JSON-serializable: convert it via `dataclasses.asdict`
-    // (which emits Rust field names) and rewrite the keys to serde wire names so renamed fields
-    // survive. A plain dict / JSON-native value already uses wire names and passes straight through.
-    if value.hasattr("__dataclass_fields__")? {
-        let as_dict = py.import("dataclasses")?.call_method1("asdict", (value,))?;
-        let json_str: String = py.import("json")?.call_method1("dumps", (as_dict,))?.extract()?;
-        let mut json_value: serde_json::Value =
-            serde_json::from_str(&json_str).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
-        __alef_apply_aliases(&mut json_value, aliases);
-        serde_json::from_value(json_value).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
-    } else {
-        let json_str: String = py.import("json")?.call_method1("dumps", (value,))?.extract()?;
-        serde_json::from_str(&json_str).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
-    }
-}
-
-fn __alef_coerce_dto_seq<T: serde::de::DeserializeOwned>(
-    py: Python<'_>,
-    value: &Bound<'_, pyo3::types::PyAny>,
-    aliases: &[__AlefAlias],
-) -> PyResult<Vec<T>> {
-    let items: Vec<Bound<'_, pyo3::types::PyAny>> = value.extract()?;
-    let mut out = Vec::with_capacity(items.len());
-    for item in &items {
-        out.push(__alef_coerce_dto(py, item, aliases)?);
-    }
-    Ok(out)
-}
-
-fn __alef_coerce_dto_map<T: serde::de::DeserializeOwned>(
-    py: Python<'_>,
-    value: &Bound<'_, pyo3::types::PyAny>,
-    aliases: &[__AlefAlias],
-) -> PyResult<T> {
-    // Build a wire-keyed JSON object from the mapping's items (each value coerced like a DTO via
-    // the object helper), then deserialize the whole map into the core type.
-    let items: Vec<(String, Bound<'_, pyo3::types::PyAny>)> = value.call_method0("items")?.extract()?;
-    let mut object = serde_json::Map::with_capacity(items.len());
-    for (key, val) in &items {
-        object.insert(key.clone(), __alef_coerce_dto(py, val, aliases)?);
-    }
-    serde_json::from_value(serde_json::Value::Object(object))
-        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
-}"#;
-
-/// The module-const identifier holding the `&[__AlefAlias]` rename schema for a coercible DTO
-/// (`LlmConfig` → `__ALEF_WIRE_LLM_CONFIG`). Shared between the pyo3 backend (which emits the const)
-/// and the variant-constructor call site (which references it) so there is a single naming path.
-pub fn pyo3_wire_schema_const_name(type_name: &str) -> String {
-    use heck::ToShoutySnakeCase;
-    format!("__ALEF_WIRE_{}", type_name.to_shouty_snake_case())
-}
-
-/// The JSON shape a coercible payload field takes, selecting which runtime coercion helper the
-/// generated factory calls.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum CoercibleShape {
-    /// A single DTO (`Named` / `Optional<Named>`) → `__alef_coerce_dto`.
-    Object,
-    /// A list of DTOs (`Vec<Named>` / `Optional<Vec<Named>>`) → `__alef_coerce_dto_seq`.
-    Seq,
-    /// A string-keyed map of DTOs (`Map<_, Named>` / `Optional<Map<_, Named>>`) → `__alef_coerce_dto_map`.
-    Map,
-}
-
-impl CoercibleShape {
-    /// The `__AlefKind` variant name this shape recurses as in a `__ALEF_WIRE_*` rename schema.
-    pub fn wire_kind(self) -> &'static str {
-        match self {
-            CoercibleShape::Object => "Object",
-            CoercibleShape::Seq => "Seq",
-            CoercibleShape::Map => "Map",
-        }
-    }
-}
-
-/// Resolve the coercible config-DTO a variant payload field carries and the JSON shape of its value.
-/// `Optional` is transparent. Returns `None` when the field is not (or does not contain) a coercible
-/// DTO — those keep the compiled-instance `.into()` path. The returned `&str` is the DTO type name,
-/// used to select its `__ALEF_WIRE_*` rename schema. Single source of truth for both the
-/// variant-constructor call site and the pyo3 backend's rename-schema generation.
-pub fn coercible_payload<'a>(ty: &'a TypeRef, coercible: &AHashSet<&str>) -> Option<(&'a str, CoercibleShape)> {
-    let named_if_coercible = |t: &'a TypeRef| match t {
-        TypeRef::Named(n) if coercible.contains(n.as_str()) => Some(n.as_str()),
-        _ => None,
-    };
-    match ty {
-        TypeRef::Optional(inner) => coercible_payload(inner, coercible),
-        TypeRef::Vec(inner) => named_if_coercible(inner).map(|n| (n, CoercibleShape::Seq)),
-        TypeRef::Map(_, value) => named_if_coercible(value).map(|n| (n, CoercibleShape::Map)),
-        TypeRef::Named(_) => named_if_coercible(ty).map(|n| (n, CoercibleShape::Object)),
-        _ => None,
-    }
-}
-
-/// True when any generated variant constructor of `enum_def` has a coercible config-DTO payload
-/// field — i.e. the [`PYO3_DTO_COERCE_HELPER`] runtime helper must be emitted into the module.
-pub fn data_enum_needs_dto_coercion(enum_def: &EnumDef, coercible_dto_names: &AHashSet<&str>) -> bool {
-    if !enum_has_data_variants(enum_def) {
-        return false;
-    }
-    collect_variant_constructors(enum_def).iter().any(|c| {
-        c.params
-            .iter()
-            .any(|p| coercible_payload(&p.ty, coercible_dto_names).is_some())
-    })
-}
 
 /// Returns true if any variant of the enum has data fields.
 /// These enums cannot be represented as flat integer enums in bindings.
@@ -232,8 +59,9 @@ pub fn gen_pyo3_data_enum_with_mapper(
 /// Like [`gen_pyo3_data_enum_with_mapper`] but also threads the set of dataclass-backed config-DTO
 /// type names. A variant-constructor payload field whose `Named` type is in `coercible_dto_names`
 /// is generated to accept the public wrapper (a `@dataclass`) or a `dict` — coerced into the core
-/// type via [`PYO3_DTO_COERCE_HELPER`] — instead of demanding the compiled `#[pyclass]` instance.
-/// This restores parity with struct-field coercion (`_to_rust_*`) for enum-variant payloads.
+/// type via the [`super::dto_coercion`] runtime helper — instead of demanding the compiled
+/// `#[pyclass]` instance. Restores parity with struct-field coercion (`_to_rust_*`) for enum-variant
+/// payloads.
 pub fn gen_pyo3_data_enum_with_coercion(
     enum_def: &EnumDef,
     core_import: &str,
@@ -568,34 +396,6 @@ fn gen_pyo3_enum_variant_constructors_content(
     }
 
     out.trim_end().to_string()
-}
-
-/// Build the struct-literal init expression for a coercible config-DTO payload field. The param
-/// arrives as `&Bound<PyAny>` (or `Option<&Bound<PyAny>>` when optional/promoted) and is routed
-/// through the shape-appropriate `__alef_coerce_dto*` helper, whose target core type is resolved by
-/// inference from the variant literal slot — so the core type path is never named (non-re-exported
-/// core DTOs work unchanged). The `dto` type name selects the per-DTO `&[__AlefAlias]` rename schema
-/// const so the dataclass round-trips with full serde-rename fidelity (a `Seq`/`Map` field applies
-/// it to each element/value).
-///
-/// `promoted` is true when the binding signature widened a non-optional core field to `Option<T>`
-/// because it follows an optional param; the coerced value is unwrapped to the field default.
-fn coercible_field_init(name: &str, dto: &str, shape: CoercibleShape, optional: bool, promoted: bool) -> String {
-    let schema = pyo3_wire_schema_const_name(dto);
-    let helper = match shape {
-        CoercibleShape::Object => "__alef_coerce_dto",
-        CoercibleShape::Seq => "__alef_coerce_dto_seq",
-        CoercibleShape::Map => "__alef_coerce_dto_map",
-    };
-    if optional {
-        // Genuinely-optional core field: keep the `Option`, coercing the inner value when present.
-        format!("{name}.map(|v| {helper}(py, v, {schema})).transpose()?")
-    } else if promoted {
-        // Core field is `T` but the param arrived as `Option<&Bound>`: coerce then unwrap to default.
-        format!("{name}.map(|v| {helper}(py, v, {schema})).transpose()?.unwrap_or_default()")
-    } else {
-        format!("{helper}(py, {name}, {schema})?")
-    }
 }
 
 /// Convert a Rust PascalCase variant name to `UPPER_SNAKE_CASE` for PyO3 `#[pyo3(name = "...")]`.

--- a/src/codegen/generators/enums.rs
+++ b/src/codegen/generators/enums.rs
@@ -1,6 +1,54 @@
 use crate::codegen::generators::RustBindingConfig;
 use crate::codegen::type_mapper::TypeMapper;
 use crate::core::ir::{EnumDef, TypeRef};
+use ahash::AHashSet;
+
+/// Module-level runtime helper coercing a public payload (dataclass / dict / JSON-native value)
+/// into a core type via serde. Emitted once per pyo3 module when any data-enum variant constructor
+/// has a coercible config-DTO field. Mirrors the struct-field `_to_rust_*` coercion on the Python
+/// side so enum-variant payloads accept the same inputs (the public `LlmConfig` dataclass or a
+/// `dict`), instead of demanding the compiled `#[pyclass]` instance.
+pub const PYO3_DTO_COERCE_HELPER: &str = r#"fn __alef_coerce_dto<T: serde::de::DeserializeOwned>(
+    py: Python<'_>,
+    value: &Bound<'_, pyo3::types::PyAny>,
+) -> PyResult<T> {
+    // Dataclass instances are not directly JSON-serializable; route them through
+    // `dataclasses.asdict` first. Plain dicts and JSON-native values pass straight to `json.dumps`.
+    let payload = if value.hasattr("__dataclass_fields__")? {
+        py.import("dataclasses")?.call_method1("asdict", (value,))?
+    } else {
+        value.clone()
+    };
+    let json_str: String = py.import("json")?.call_method1("dumps", (payload,))?.extract()?;
+    serde_json::from_str(&json_str).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+}"#;
+
+/// Extract the leaf `Named` type name from `Named(n)` or `Optional(Named(n))`. Returns `None` for
+/// every other shape (primitive, `Vec`, `Path`, …). Used to test whether a variant-constructor
+/// payload field is a coercible config DTO.
+fn dto_named_name(ty: &TypeRef) -> Option<&str> {
+    match ty {
+        TypeRef::Named(n) => Some(n.as_str()),
+        TypeRef::Optional(inner) => match inner.as_ref() {
+            TypeRef::Named(n) => Some(n.as_str()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// True when any generated variant constructor of `enum_def` has a coercible config-DTO payload
+/// field — i.e. the [`PYO3_DTO_COERCE_HELPER`] runtime helper must be emitted into the module.
+pub fn data_enum_needs_dto_coercion(enum_def: &EnumDef, coercible_dto_names: &AHashSet<&str>) -> bool {
+    if !enum_has_data_variants(enum_def) {
+        return false;
+    }
+    collect_variant_constructors(enum_def).iter().any(|c| {
+        c.params
+            .iter()
+            .any(|p| dto_named_name(&p.ty).is_some_and(|n| coercible_dto_names.contains(n)))
+    })
+}
 
 /// Returns true if any variant of the enum has data fields.
 /// These enums cannot be represented as flat integer enums in bindings.
@@ -43,10 +91,27 @@ pub fn gen_pyo3_data_enum(enum_def: &EnumDef, core_import: &str) -> String {
 /// `#[staticmethod]` constructor inside the `#[pymethods]` impl block — `Shape.circle(radius=...)`
 /// rather than the stringly-typed `Shape(type="circle", ...)` form. The mapper maps each field's
 /// type into the binding signature. Without a mapper the constructor section is omitted.
+///
+/// Delegates to [`gen_pyo3_data_enum_with_coercion`] with no config-DTO coercion (empty set) — the
+/// stable entry point for callers that don't classify dataclass-backed types.
 pub fn gen_pyo3_data_enum_with_mapper(
     enum_def: &EnumDef,
     core_import: &str,
     mapper: Option<&dyn TypeMapper>,
+) -> String {
+    gen_pyo3_data_enum_with_coercion(enum_def, core_import, mapper, &AHashSet::new())
+}
+
+/// Like [`gen_pyo3_data_enum_with_mapper`] but also threads the set of dataclass-backed config-DTO
+/// type names. A variant-constructor payload field whose `Named` type is in `coercible_dto_names`
+/// is generated to accept the public wrapper (a `@dataclass`) or a `dict` — coerced into the core
+/// type via [`PYO3_DTO_COERCE_HELPER`] — instead of demanding the compiled `#[pyclass]` instance.
+/// This restores parity with struct-field coercion (`_to_rust_*`) for enum-variant payloads.
+pub fn gen_pyo3_data_enum_with_coercion(
+    enum_def: &EnumDef,
+    core_import: &str,
+    mapper: Option<&dyn TypeMapper>,
+    coercible_dto_names: &AHashSet<&str>,
 ) -> String {
     let name = &enum_def.name;
     let core_path = crate::codegen::conversions::core_enum_path(enum_def, core_import);
@@ -81,7 +146,7 @@ pub fn gen_pyo3_data_enum_with_mapper(
     // Generate a per-variant constructor for each data-carrying struct variant when a mapper
     // is provided (the mapper maps field types into the binding signature).
     let variant_constructors_content = match mapper {
-        Some(m) => gen_pyo3_enum_variant_constructors_content(enum_def, &core_path, m),
+        Some(m) => gen_pyo3_enum_variant_constructors_content(enum_def, &core_path, m, coercible_dto_names),
         None => String::new(),
     };
 
@@ -273,7 +338,12 @@ pub(crate) fn variant_field_init(
 /// directly via [`variant_field_init`]. Every generated constructor collides with the variant
 /// accessor of the same snake_case name, so they always use the `_factory_<name>` Rust ident plus
 /// `#[pyo3(name = "<name>")]`.
-fn gen_pyo3_enum_variant_constructors_content(enum_def: &EnumDef, core_path: &str, mapper: &dyn TypeMapper) -> String {
+fn gen_pyo3_enum_variant_constructors_content(
+    enum_def: &EnumDef,
+    core_path: &str,
+    mapper: &dyn TypeMapper,
+    coercible_dto_names: &AHashSet<&str>,
+) -> String {
     use crate::codegen::shared::{function_params, function_sig_defaults, is_promoted_optional};
 
     let constructors = collect_variant_constructors(enum_def);
@@ -281,11 +351,31 @@ fn gen_pyo3_enum_variant_constructors_content(enum_def: &EnumDef, core_path: &st
         return String::new();
     }
 
-    let map_fn = |ty: &TypeRef| mapper.map_type(ty);
+    // True for a payload field whose `Named` type is a dataclass-backed config DTO: its public
+    // wrapper is a `@dataclass`/`dict`, not the compiled `#[pyclass]`, so it must be coerced.
+    let is_coercible = |ty: &TypeRef| dto_named_name(ty).is_some_and(|n| coercible_dto_names.contains(n));
+
+    // A coercible field accepts `&Bound<PyAny>` (the public wrapper or a dict) rather than the
+    // compiled type. `function_params_vec` wraps optional/promoted params in `Option<…>`.
+    let map_fn = |ty: &TypeRef| {
+        if is_coercible(ty) {
+            "&Bound<'_, pyo3::types::PyAny>".to_string()
+        } else {
+            mapper.map_type(ty)
+        }
+    };
 
     let mut out = String::new();
     for ctor in &constructors {
+        // A constructor with any coercible payload calls the fallible `__alef_coerce_dto` helper,
+        // so it takes `py` and returns `PyResult<Self>`.
+        let needs_coercion = ctor.params.iter().any(|p| is_coercible(&p.ty));
         let params_str = function_params(&ctor.params, &map_fn);
+        let params_str = if needs_coercion {
+            format!("py: Python<'_>, {params_str}")
+        } else {
+            params_str
+        };
 
         // Build each `field: <expr>` init inline. `field: field` collapses to the shorthand `field`
         // for an unchanged passthrough.
@@ -294,8 +384,13 @@ fn gen_pyo3_enum_variant_constructors_content(enum_def: &EnumDef, core_path: &st
             .iter()
             .enumerate()
             .map(|(idx, p)| {
-                // pyo3 does not remap primitives, so no numeric cast back to the core type.
-                let expr = variant_field_init(p, is_promoted_optional(&ctor.params, idx), false, false);
+                let promoted = is_promoted_optional(&ctor.params, idx);
+                let expr = if is_coercible(&p.ty) {
+                    coercible_field_init(&p.name, p.optional, promoted)
+                } else {
+                    // pyo3 does not remap primitives, so no numeric cast back to the core type.
+                    variant_field_init(p, promoted, false, false)
+                };
                 if expr == p.name {
                     p.name.clone()
                 } else {
@@ -337,6 +432,7 @@ fn gen_pyo3_enum_variant_constructors_content(enum_def: &EnumDef, core_path: &st
                 signature_defaults => signature_defaults,
                 rust_fn_name => rust_fn_name,
                 params => params_str,
+                returns_result => needs_coercion,
                 body_lines => body_lines,
             },
         ));
@@ -344,6 +440,25 @@ fn gen_pyo3_enum_variant_constructors_content(enum_def: &EnumDef, core_path: &st
     }
 
     out.trim_end().to_string()
+}
+
+/// Build the struct-literal init expression for a coercible config-DTO payload field. The param
+/// arrives as `&Bound<PyAny>` (or `Option<&Bound<PyAny>>` when optional/promoted) and is routed
+/// through `__alef_coerce_dto`, whose target core type is resolved by inference from the variant
+/// literal slot — so the core type path is never named (non-re-exported core DTOs work unchanged).
+///
+/// `promoted` is true when the binding signature widened a non-optional core field to `Option<T>`
+/// because it follows an optional param; the coerced value is unwrapped to the field default.
+fn coercible_field_init(name: &str, optional: bool, promoted: bool) -> String {
+    if optional {
+        // Genuinely-optional core field: keep the `Option`, coercing the inner value when present.
+        format!("{name}.map(|v| __alef_coerce_dto(py, v)).transpose()?")
+    } else if promoted {
+        // Core field is `T` but the param arrived as `Option<&Bound>`: coerce then unwrap to default.
+        format!("{name}.map(|v| __alef_coerce_dto(py, v)).transpose()?.unwrap_or_default()")
+    } else {
+        format!("__alef_coerce_dto(py, {name})?")
+    }
 }
 
 /// Convert a Rust PascalCase variant name to `UPPER_SNAKE_CASE` for PyO3 `#[pyo3(name = "...")]`.

--- a/src/codegen/generators/enums.rs
+++ b/src/codegen/generators/enums.rs
@@ -8,31 +8,158 @@ use ahash::AHashSet;
 /// has a coercible config-DTO field. Mirrors the struct-field `_to_rust_*` coercion on the Python
 /// side so enum-variant payloads accept the same inputs (the public `LlmConfig` dataclass or a
 /// `dict`), instead of demanding the compiled `#[pyclass]` instance.
-pub const PYO3_DTO_COERCE_HELPER: &str = r#"fn __alef_coerce_dto<T: serde::de::DeserializeOwned>(
+///
+/// The helper is non-parameterized (this rule allows a static `const` for non-interpolated code).
+/// Per-DTO rename fidelity is supplied at the call site as a runtime `&[__AlefAlias]` schema (the
+/// `__ALEF_WIRE_*` module consts emitted by the pyo3 backend), so a dataclass whose fields use
+/// `#[serde(rename)]` or `#[serde(rename_all)]` — including nested DTOs, sequences, maps, and
+/// optionals — round-trips faithfully. Plain dicts already carry serde wire names and pass straight
+/// through without remapping.
+pub const PYO3_DTO_COERCE_HELPER: &str = r#"struct __AlefAlias {
+    rust: &'static str,
+    wire: &'static str,
+    kind: __AlefKind,
+    nested: &'static [__AlefAlias],
+}
+
+enum __AlefKind {
+    Leaf,
+    Object,
+    Seq,
+    Map,
+}
+
+fn __alef_apply_aliases(value: &mut serde_json::Value, aliases: &[__AlefAlias]) {
+    let serde_json::Value::Object(map) = value else {
+        return;
+    };
+    for alias in aliases {
+        if !alias.nested.is_empty() {
+            if let Some(child) = map.get_mut(alias.rust) {
+                match alias.kind {
+                    __AlefKind::Object => __alef_apply_aliases(child, alias.nested),
+                    __AlefKind::Seq => {
+                        if let serde_json::Value::Array(items) = child {
+                            for item in items.iter_mut() {
+                                __alef_apply_aliases(item, alias.nested);
+                            }
+                        }
+                    }
+                    __AlefKind::Map => {
+                        if let serde_json::Value::Object(entries) = child {
+                            for entry in entries.values_mut() {
+                                __alef_apply_aliases(entry, alias.nested);
+                            }
+                        }
+                    }
+                    __AlefKind::Leaf => {}
+                }
+            }
+        }
+        if alias.rust != alias.wire {
+            if let Some(taken) = map.remove(alias.rust) {
+                map.insert(alias.wire.to_string(), taken);
+            }
+        }
+    }
+}
+
+fn __alef_coerce_dto<T: serde::de::DeserializeOwned>(
     py: Python<'_>,
     value: &Bound<'_, pyo3::types::PyAny>,
+    aliases: &[__AlefAlias],
 ) -> PyResult<T> {
-    // Dataclass instances are not directly JSON-serializable; route them through
-    // `dataclasses.asdict` first. Plain dicts and JSON-native values pass straight to `json.dumps`.
-    let payload = if value.hasattr("__dataclass_fields__")? {
-        py.import("dataclasses")?.call_method1("asdict", (value,))?
+    // A public @dataclass is not directly JSON-serializable: convert it via `dataclasses.asdict`
+    // (which emits Rust field names) and rewrite the keys to serde wire names so renamed fields
+    // survive. A plain dict / JSON-native value already uses wire names and passes straight through.
+    if value.hasattr("__dataclass_fields__")? {
+        let as_dict = py.import("dataclasses")?.call_method1("asdict", (value,))?;
+        let json_str: String = py.import("json")?.call_method1("dumps", (as_dict,))?.extract()?;
+        let mut json_value: serde_json::Value =
+            serde_json::from_str(&json_str).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        __alef_apply_aliases(&mut json_value, aliases);
+        serde_json::from_value(json_value).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
     } else {
-        value.clone()
-    };
-    let json_str: String = py.import("json")?.call_method1("dumps", (payload,))?.extract()?;
-    serde_json::from_str(&json_str).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+        let json_str: String = py.import("json")?.call_method1("dumps", (value,))?.extract()?;
+        serde_json::from_str(&json_str).map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
+    }
+}
+
+fn __alef_coerce_dto_seq<T: serde::de::DeserializeOwned>(
+    py: Python<'_>,
+    value: &Bound<'_, pyo3::types::PyAny>,
+    aliases: &[__AlefAlias],
+) -> PyResult<Vec<T>> {
+    let items: Vec<Bound<'_, pyo3::types::PyAny>> = value.extract()?;
+    let mut out = Vec::with_capacity(items.len());
+    for item in &items {
+        out.push(__alef_coerce_dto(py, item, aliases)?);
+    }
+    Ok(out)
+}
+
+fn __alef_coerce_dto_map<T: serde::de::DeserializeOwned>(
+    py: Python<'_>,
+    value: &Bound<'_, pyo3::types::PyAny>,
+    aliases: &[__AlefAlias],
+) -> PyResult<T> {
+    // Build a wire-keyed JSON object from the mapping's items (each value coerced like a DTO via
+    // the object helper), then deserialize the whole map into the core type.
+    let items: Vec<(String, Bound<'_, pyo3::types::PyAny>)> = value.call_method0("items")?.extract()?;
+    let mut object = serde_json::Map::with_capacity(items.len());
+    for (key, val) in &items {
+        object.insert(key.clone(), __alef_coerce_dto(py, val, aliases)?);
+    }
+    serde_json::from_value(serde_json::Value::Object(object))
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))
 }"#;
 
-/// Extract the leaf `Named` type name from `Named(n)` or `Optional(Named(n))`. Returns `None` for
-/// every other shape (primitive, `Vec`, `Path`, …). Used to test whether a variant-constructor
-/// payload field is a coercible config DTO.
-fn dto_named_name(ty: &TypeRef) -> Option<&str> {
+/// The module-const identifier holding the `&[__AlefAlias]` rename schema for a coercible DTO
+/// (`LlmConfig` → `__ALEF_WIRE_LLM_CONFIG`). Shared between the pyo3 backend (which emits the const)
+/// and the variant-constructor call site (which references it) so there is a single naming path.
+pub fn pyo3_wire_schema_const_name(type_name: &str) -> String {
+    use heck::ToShoutySnakeCase;
+    format!("__ALEF_WIRE_{}", type_name.to_shouty_snake_case())
+}
+
+/// The JSON shape a coercible payload field takes, selecting which runtime coercion helper the
+/// generated factory calls.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum CoercibleShape {
+    /// A single DTO (`Named` / `Optional<Named>`) → `__alef_coerce_dto`.
+    Object,
+    /// A list of DTOs (`Vec<Named>` / `Optional<Vec<Named>>`) → `__alef_coerce_dto_seq`.
+    Seq,
+    /// A string-keyed map of DTOs (`Map<_, Named>` / `Optional<Map<_, Named>>`) → `__alef_coerce_dto_map`.
+    Map,
+}
+
+impl CoercibleShape {
+    /// The `__AlefKind` variant name this shape recurses as in a `__ALEF_WIRE_*` rename schema.
+    pub fn wire_kind(self) -> &'static str {
+        match self {
+            CoercibleShape::Object => "Object",
+            CoercibleShape::Seq => "Seq",
+            CoercibleShape::Map => "Map",
+        }
+    }
+}
+
+/// Resolve the coercible config-DTO a variant payload field carries and the JSON shape of its value.
+/// `Optional` is transparent. Returns `None` when the field is not (or does not contain) a coercible
+/// DTO — those keep the compiled-instance `.into()` path. The returned `&str` is the DTO type name,
+/// used to select its `__ALEF_WIRE_*` rename schema. Single source of truth for both the
+/// variant-constructor call site and the pyo3 backend's rename-schema generation.
+pub fn coercible_payload<'a>(ty: &'a TypeRef, coercible: &AHashSet<&str>) -> Option<(&'a str, CoercibleShape)> {
+    let named_if_coercible = |t: &'a TypeRef| match t {
+        TypeRef::Named(n) if coercible.contains(n.as_str()) => Some(n.as_str()),
+        _ => None,
+    };
     match ty {
-        TypeRef::Named(n) => Some(n.as_str()),
-        TypeRef::Optional(inner) => match inner.as_ref() {
-            TypeRef::Named(n) => Some(n.as_str()),
-            _ => None,
-        },
+        TypeRef::Optional(inner) => coercible_payload(inner, coercible),
+        TypeRef::Vec(inner) => named_if_coercible(inner).map(|n| (n, CoercibleShape::Seq)),
+        TypeRef::Map(_, value) => named_if_coercible(value).map(|n| (n, CoercibleShape::Map)),
+        TypeRef::Named(_) => named_if_coercible(ty).map(|n| (n, CoercibleShape::Object)),
         _ => None,
     }
 }
@@ -46,7 +173,7 @@ pub fn data_enum_needs_dto_coercion(enum_def: &EnumDef, coercible_dto_names: &AH
     collect_variant_constructors(enum_def).iter().any(|c| {
         c.params
             .iter()
-            .any(|p| dto_named_name(&p.ty).is_some_and(|n| coercible_dto_names.contains(n)))
+            .any(|p| coercible_payload(&p.ty, coercible_dto_names).is_some())
     })
 }
 
@@ -351,11 +478,12 @@ fn gen_pyo3_enum_variant_constructors_content(
         return String::new();
     }
 
-    // True for a payload field whose `Named` type is a dataclass-backed config DTO: its public
-    // wrapper is a `@dataclass`/`dict`, not the compiled `#[pyclass]`, so it must be coerced.
-    let is_coercible = |ty: &TypeRef| dto_named_name(ty).is_some_and(|n| coercible_dto_names.contains(n));
+    // A payload field is coercible when its (possibly `Vec`/`Map`/`Optional`-wrapped) `Named` type
+    // is a dataclass-backed config DTO: its public wrapper is a `@dataclass`/`dict`, not the compiled
+    // `#[pyclass]`, so it must be coerced rather than required as the compiled instance.
+    let is_coercible = |ty: &TypeRef| coercible_payload(ty, coercible_dto_names).is_some();
 
-    // A coercible field accepts `&Bound<PyAny>` (the public wrapper or a dict) rather than the
+    // A coercible field accepts `&Bound<PyAny>` (the public wrapper / list / dict) rather than the
     // compiled type. `function_params_vec` wraps optional/promoted params in `Option<…>`.
     let map_fn = |ty: &TypeRef| {
         if is_coercible(ty) {
@@ -367,7 +495,7 @@ fn gen_pyo3_enum_variant_constructors_content(
 
     let mut out = String::new();
     for ctor in &constructors {
-        // A constructor with any coercible payload calls the fallible `__alef_coerce_dto` helper,
+        // A constructor with any coercible payload calls a fallible `__alef_coerce_dto*` helper,
         // so it takes `py` and returns `PyResult<Self>`.
         let needs_coercion = ctor.params.iter().any(|p| is_coercible(&p.ty));
         let params_str = function_params(&ctor.params, &map_fn);
@@ -385,8 +513,8 @@ fn gen_pyo3_enum_variant_constructors_content(
             .enumerate()
             .map(|(idx, p)| {
                 let promoted = is_promoted_optional(&ctor.params, idx);
-                let expr = if is_coercible(&p.ty) {
-                    coercible_field_init(&p.name, p.optional, promoted)
+                let expr = if let Some((dto, shape)) = coercible_payload(&p.ty, coercible_dto_names) {
+                    coercible_field_init(&p.name, dto, shape, p.optional, promoted)
                 } else {
                     // pyo3 does not remap primitives, so no numeric cast back to the core type.
                     variant_field_init(p, promoted, false, false)
@@ -444,20 +572,29 @@ fn gen_pyo3_enum_variant_constructors_content(
 
 /// Build the struct-literal init expression for a coercible config-DTO payload field. The param
 /// arrives as `&Bound<PyAny>` (or `Option<&Bound<PyAny>>` when optional/promoted) and is routed
-/// through `__alef_coerce_dto`, whose target core type is resolved by inference from the variant
-/// literal slot — so the core type path is never named (non-re-exported core DTOs work unchanged).
+/// through the shape-appropriate `__alef_coerce_dto*` helper, whose target core type is resolved by
+/// inference from the variant literal slot — so the core type path is never named (non-re-exported
+/// core DTOs work unchanged). The `dto` type name selects the per-DTO `&[__AlefAlias]` rename schema
+/// const so the dataclass round-trips with full serde-rename fidelity (a `Seq`/`Map` field applies
+/// it to each element/value).
 ///
 /// `promoted` is true when the binding signature widened a non-optional core field to `Option<T>`
 /// because it follows an optional param; the coerced value is unwrapped to the field default.
-fn coercible_field_init(name: &str, optional: bool, promoted: bool) -> String {
+fn coercible_field_init(name: &str, dto: &str, shape: CoercibleShape, optional: bool, promoted: bool) -> String {
+    let schema = pyo3_wire_schema_const_name(dto);
+    let helper = match shape {
+        CoercibleShape::Object => "__alef_coerce_dto",
+        CoercibleShape::Seq => "__alef_coerce_dto_seq",
+        CoercibleShape::Map => "__alef_coerce_dto_map",
+    };
     if optional {
         // Genuinely-optional core field: keep the `Option`, coercing the inner value when present.
-        format!("{name}.map(|v| __alef_coerce_dto(py, v)).transpose()?")
+        format!("{name}.map(|v| {helper}(py, v, {schema})).transpose()?")
     } else if promoted {
         // Core field is `T` but the param arrived as `Option<&Bound>`: coerce then unwrap to default.
-        format!("{name}.map(|v| __alef_coerce_dto(py, v)).transpose()?.unwrap_or_default()")
+        format!("{name}.map(|v| {helper}(py, v, {schema})).transpose()?.unwrap_or_default()")
     } else {
-        format!("__alef_coerce_dto(py, {name})?")
+        format!("{helper}(py, {name}, {schema})?")
     }
 }
 

--- a/src/codegen/generators/enums/tests.rs
+++ b/src/codegen/generators/enums/tests.rs
@@ -271,6 +271,104 @@ fn variant_constructors_convert_named_dto_fields() {
 }
 
 #[test]
+fn variant_constructors_coerce_dataclass_backed_dto_field() {
+    use crate::codegen::generators::gen_pyo3_data_enum_with_coercion;
+    use crate::codegen::type_mapper::IdentityMapper;
+    use ahash::AHashSet;
+    // A payload field whose Named type is a dataclass-backed config DTO accepts the public wrapper
+    // (a @dataclass) or a dict via `&Bound<PyAny>` and is coerced through the runtime helper, rather
+    // than demanding the compiled `#[pyclass]`. The factory therefore takes `py` and is fallible.
+    // (xberg #1165: enum-variant payloads must coerce like struct fields do.)
+    let def = enum_def(
+        "Wrapper",
+        vec![variant(
+            "Llm",
+            vec![typed_field("llm", TypeRef::Named("LlmConfig".to_string()))],
+        )],
+    );
+    let coercible: AHashSet<&str> = ["LlmConfig"].into_iter().collect();
+
+    let generated = gen_pyo3_data_enum_with_coercion(&def, "core", Some(&IdentityMapper), &coercible);
+
+    assert!(
+        generated
+            .contains("pub fn _factory_llm(py: Python<'_>, llm: &Bound<'_, pyo3::types::PyAny>) -> PyResult<Self>"),
+        "{generated}"
+    );
+    assert!(
+        generated.contains("Ok(Self { inner: crate::Wrapper::Llm { llm: __alef_coerce_dto(py, llm)? } })"),
+        "{generated}"
+    );
+    // The compiled-type-only path is gone.
+    assert!(!generated.contains("llm: llm.into()"), "{generated}");
+    // The module-level runtime helper is emitted exactly when needed.
+    assert!(
+        crate::codegen::generators::data_enum_needs_dto_coercion(&def, &coercible),
+        "expected coercion to be flagged"
+    );
+}
+
+#[test]
+fn variant_constructors_coerce_only_dto_leaving_primitive_typed() {
+    use crate::codegen::generators::gen_pyo3_data_enum_with_coercion;
+    use crate::codegen::type_mapper::IdentityMapper;
+    use ahash::AHashSet;
+    // Coercion is gated strictly: only the dataclass-backed DTO field becomes `&Bound<PyAny>`; the
+    // sibling primitive keeps its concrete type and shorthand init.
+    let def = enum_def(
+        "Job",
+        vec![variant(
+            "Run",
+            vec![
+                typed_field("retries", TypeRef::Primitive(PrimitiveType::U32)),
+                typed_field("config", TypeRef::Named("RunConfig".to_string())),
+            ],
+        )],
+    );
+    let coercible: AHashSet<&str> = ["RunConfig"].into_iter().collect();
+
+    let generated = gen_pyo3_data_enum_with_coercion(&def, "core", Some(&IdentityMapper), &coercible);
+
+    assert!(
+        generated.contains(
+            "pub fn _factory_run(py: Python<'_>, retries: u32, config: &Bound<'_, pyo3::types::PyAny>) -> PyResult<Self>"
+        ),
+        "{generated}"
+    );
+    assert!(
+        generated.contains("Ok(Self { inner: crate::Job::Run { retries, config: __alef_coerce_dto(py, config)? } })"),
+        "{generated}"
+    );
+}
+
+#[test]
+fn variant_constructors_skip_coercion_for_non_dataclass_named_field() {
+    use crate::codegen::generators::{data_enum_needs_dto_coercion, gen_pyo3_data_enum_with_coercion};
+    use crate::codegen::type_mapper::IdentityMapper;
+    use ahash::AHashSet;
+    // A Named field that is NOT a dataclass-backed config DTO (e.g. a native-return type) stays on
+    // the `.into()` path and the factory remains infallible — no `py` param, no helper.
+    let def = enum_def(
+        "Wrapper",
+        vec![variant(
+            "Llm",
+            vec![typed_field("llm", TypeRef::Named("LlmConfig".to_string()))],
+        )],
+    );
+    let empty: AHashSet<&str> = AHashSet::new();
+
+    let generated = gen_pyo3_data_enum_with_coercion(&def, "core", Some(&IdentityMapper), &empty);
+
+    assert!(
+        generated.contains("pub fn _factory_llm(llm: LlmConfig) -> Self"),
+        "{generated}"
+    );
+    assert!(generated.contains("llm: llm.into()"), "{generated}");
+    assert!(!generated.contains("__alef_coerce_dto"), "{generated}");
+    assert!(!data_enum_needs_dto_coercion(&def, &empty), "should not flag coercion");
+}
+
+#[test]
 fn variant_constructors_pair_interleaved_field_exprs_by_position() {
     use crate::codegen::type_mapper::IdentityMapper;
     // Interleave a primitive, a Named-DTO (`.into()`), and a Vec<Named> DTO

--- a/src/codegen/generators/enums/tests.rs
+++ b/src/codegen/generators/enums/tests.rs
@@ -296,7 +296,9 @@ fn variant_constructors_coerce_dataclass_backed_dto_field() {
         "{generated}"
     );
     assert!(
-        generated.contains("Ok(Self { inner: crate::Wrapper::Llm { llm: __alef_coerce_dto(py, llm)? } })"),
+        generated.contains(
+            "Ok(Self { inner: crate::Wrapper::Llm { llm: __alef_coerce_dto(py, llm, __ALEF_WIRE_LLM_CONFIG)? } })"
+        ),
         "{generated}"
     );
     // The compiled-type-only path is gone.
@@ -336,7 +338,9 @@ fn variant_constructors_coerce_only_dto_leaving_primitive_typed() {
         "{generated}"
     );
     assert!(
-        generated.contains("Ok(Self { inner: crate::Job::Run { retries, config: __alef_coerce_dto(py, config)? } })"),
+        generated.contains(
+            "Ok(Self { inner: crate::Job::Run { retries, config: __alef_coerce_dto(py, config, __ALEF_WIRE_RUN_CONFIG)? } })"
+        ),
         "{generated}"
     );
 }
@@ -366,6 +370,52 @@ fn variant_constructors_skip_coercion_for_non_dataclass_named_field() {
     assert!(generated.contains("llm: llm.into()"), "{generated}");
     assert!(!generated.contains("__alef_coerce_dto"), "{generated}");
     assert!(!data_enum_needs_dto_coercion(&def, &empty), "should not flag coercion");
+}
+
+#[test]
+fn variant_constructors_coerce_vec_and_map_of_dto_payloads() {
+    use crate::codegen::generators::gen_pyo3_data_enum_with_coercion;
+    use crate::codegen::type_mapper::IdentityMapper;
+    use ahash::AHashSet;
+    // A `Vec<DTO>` payload coerces each element (`__alef_coerce_dto_seq`) and a `Map<_, DTO>`
+    // payload coerces each value (`__alef_coerce_dto_map`); both accept lists/dicts of public
+    // wrappers, not compiled instances.
+    let def = enum_def(
+        "Pipeline",
+        vec![variant(
+            "Run",
+            vec![
+                typed_field(
+                    "stages",
+                    TypeRef::Vec(Box::new(TypeRef::Named("StageConfig".to_string()))),
+                ),
+                typed_field(
+                    "overrides",
+                    TypeRef::Map(
+                        Box::new(TypeRef::String),
+                        Box::new(TypeRef::Named("StageConfig".to_string())),
+                    ),
+                ),
+            ],
+        )],
+    );
+    let coercible: AHashSet<&str> = ["StageConfig"].into_iter().collect();
+
+    let generated = gen_pyo3_data_enum_with_coercion(&def, "core", Some(&IdentityMapper), &coercible);
+
+    assert!(
+        generated.contains("stages: __alef_coerce_dto_seq(py, stages, __ALEF_WIRE_STAGE_CONFIG)?"),
+        "{generated}"
+    );
+    assert!(
+        generated.contains("overrides: __alef_coerce_dto_map(py, overrides, __ALEF_WIRE_STAGE_CONFIG)?"),
+        "{generated}"
+    );
+    // Both params arrive as PyAny (a list / dict of public wrappers).
+    assert!(
+        generated.contains("stages: &Bound<'_, pyo3::types::PyAny>"),
+        "{generated}"
+    );
 }
 
 #[test]

--- a/src/codegen/generators/mod.rs
+++ b/src/codegen/generators/mod.rs
@@ -1,6 +1,7 @@
 use ahash::AHashMap;
 
 pub mod binding_helpers;
+pub mod dto_coercion;
 pub mod enums;
 pub mod functions;
 pub mod methods;
@@ -145,12 +146,15 @@ pub use binding_helpers::{
     gen_named_let_bindings_pub, gen_named_let_bindings_with_augmented, gen_serde_let_bindings, gen_unimplemented_body,
     has_named_params, is_simple_non_opaque_param, wrap_return, wrap_return_with_mutex, wrap_return_with_mutex_mapped,
 };
-pub use enums::{
-    CoercibleShape, PYO3_DTO_COERCE_HELPER, coercible_payload, data_enum_needs_dto_coercion, enum_has_data_variants,
-    gen_enum, gen_pyo3_data_enum, gen_pyo3_data_enum_with_coercion, gen_pyo3_data_enum_with_mapper,
+pub use dto_coercion::{
+    CoercibleShape, PYO3_DTO_COERCE_HELPER, coercible_payload, data_enum_needs_dto_coercion,
     pyo3_wire_schema_const_name,
 };
 pub(crate) use enums::{collect_variant_constructors, variant_field_init};
+pub use enums::{
+    enum_has_data_variants, gen_enum, gen_pyo3_data_enum, gen_pyo3_data_enum_with_coercion,
+    gen_pyo3_data_enum_with_mapper,
+};
 pub use functions::{
     collect_explicit_core_imports, collect_trait_imports, gen_function, gen_function_with_mutex,
     has_unresolved_trait_methods,

--- a/src/codegen/generators/mod.rs
+++ b/src/codegen/generators/mod.rs
@@ -145,8 +145,11 @@ pub use binding_helpers::{
     gen_named_let_bindings_pub, gen_named_let_bindings_with_augmented, gen_serde_let_bindings, gen_unimplemented_body,
     has_named_params, is_simple_non_opaque_param, wrap_return, wrap_return_with_mutex, wrap_return_with_mutex_mapped,
 };
+pub use enums::{
+    PYO3_DTO_COERCE_HELPER, data_enum_needs_dto_coercion, enum_has_data_variants, gen_enum, gen_pyo3_data_enum,
+    gen_pyo3_data_enum_with_coercion, gen_pyo3_data_enum_with_mapper,
+};
 pub(crate) use enums::{collect_variant_constructors, variant_field_init};
-pub use enums::{enum_has_data_variants, gen_enum, gen_pyo3_data_enum, gen_pyo3_data_enum_with_mapper};
 pub use functions::{
     collect_explicit_core_imports, collect_trait_imports, gen_function, gen_function_with_mutex,
     has_unresolved_trait_methods,

--- a/src/codegen/generators/mod.rs
+++ b/src/codegen/generators/mod.rs
@@ -146,8 +146,9 @@ pub use binding_helpers::{
     has_named_params, is_simple_non_opaque_param, wrap_return, wrap_return_with_mutex, wrap_return_with_mutex_mapped,
 };
 pub use enums::{
-    PYO3_DTO_COERCE_HELPER, data_enum_needs_dto_coercion, enum_has_data_variants, gen_enum, gen_pyo3_data_enum,
-    gen_pyo3_data_enum_with_coercion, gen_pyo3_data_enum_with_mapper,
+    CoercibleShape, PYO3_DTO_COERCE_HELPER, coercible_payload, data_enum_needs_dto_coercion, enum_has_data_variants,
+    gen_enum, gen_pyo3_data_enum, gen_pyo3_data_enum_with_coercion, gen_pyo3_data_enum_with_mapper,
+    pyo3_wire_schema_const_name,
 };
 pub(crate) use enums::{collect_variant_constructors, variant_field_init};
 pub use functions::{

--- a/src/codegen/templates/generators/enums/pyo3_factory_method.jinja
+++ b/src/codegen/templates/generators/enums/pyo3_factory_method.jinja
@@ -8,8 +8,12 @@
     #[pyo3(signature = ({{ signature_defaults }}))]
 {%- endif %}
     #[staticmethod]
-    pub fn {{ rust_fn_name }}({{ params }}) -> Self {
+    pub fn {{ rust_fn_name }}({{ params }}) -> {% if returns_result %}PyResult<Self>{% else %}Self{% endif %} {
 {%- for body_line in body_lines %}
+{%- if returns_result %}
+        Ok({{ body_line }})
+{%- else %}
         {{ body_line }}
+{%- endif %}
 {%- endfor %}
     }


### PR DESCRIPTION
**`EmbeddingModelType.llm(LlmConfig(...))` now works with the public `LlmConfig` dataclass (and a plain dict).** It used to raise `TypeError`.

```python
# before
EmbeddingModelType.llm(LlmConfig(model="openai/text-embedding-3-small"))
#   TypeError: 'LlmConfig' object is not an instance of 'LlmConfig'

# after
EmbeddingModelType.llm(LlmConfig(model="openai/text-embedding-3-small"))   # ✓ dataclass
EmbeddingModelType.llm({"model": "openai/text-embedding-3-small"})         # ✓ dict
```

Python-only — the cause is unique to the pyo3 backend.

## Why it broke

`xberg.LlmConfig` is a pure-Python `@dataclass` (the `.options` wrapper), but the generated factory `_factory_llm(llm: LlmConfig)` demanded the *compiled* pyclass and did `.into()` with no coercion. Struct *fields* already coerce a public `LlmConfig | dict` (via the `_to_rust_*` converters); the enum-variant payload path never did. `EmbeddingModelType` is a frozen native pyclass (not subclassable), so the fix has to live in the compiled factory.

## How it works

The factory for a config-DTO payload now takes `&Bound<PyAny>` (dataclass **or** dict) and coerces it into the core type through a small runtime helper, `__alef_coerce_dto`:

- **dataclass** → `dataclasses.asdict` → serde into the core type; **dict** → serde directly.
- **Rename-safe:** a per-DTO wire-name table (built from the centralized `naming::wire_field_name`) remaps Rust field names → serde wire names *before* deserializing, so `#[serde(rename)]` / `rename_all` fields don't silently drop.
- **Every payload shape:** single DTO, `Vec<DTO>`, `Map<_,DTO>`, `Optional`, and nested DTOs — all coerced (cycles broken at back-edges).
- **Tightly gated:** only dataclass-backed config DTOs are touched; primitives, enums, opaque handles, etc. — and the magnus/php/extendr factory paths — are unchanged.

## Verified

- **alef:** `fmt` + `clippy -D warnings` clean; `cargo test -p alef --lib` → 4097 pass (regression tests for per-field `rename`, `rename_all`, nesting, `Vec`/`Optional`, cycle-break).
- **Generated code compiles:** regenerated xberg's python binding and ran `cargo check -p xberg-py` clean — the emitted factory + helper + wire-name consts compile for both `EmbeddingModelType` and `RerankerModelType`.
- **ai-rules:** emitted code via Minijinja templates (helper is a non-interpolated `const`, allowed); centralized naming; regression tests; no AI signatures. Coercion lives in `dto_coercion.rs` + `wire_schema.rs`; all files ≤1000 lines.

Fixes xberg-io/xberg#1165 (generator-side; resolves for consumers after an alef release + regen).
