### PR TITLE
fix(php): convert mirrored core-type serde defaults to the binding DTO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **php**: generate the correct return type for `serde(default = "...")` helpers on fields whose
+  core type is mirrored into a binding DTO. The helper returned the core type (e.g.
+  `crawlberg::SsrfPolicy`) while the field is rendered as the crate-root mirror, so the generated
+  php crate failed to compile (`expected SsrfPolicy, found crawlberg::SsrfPolicy`). The helper now
+  returns the mirror and converts the core value via `.into()`.
+
 ## [0.30.1] - 2026-06-29
 
 ### Fixed

--- a/src/backends/php/gen_bindings/serde_defaults.rs
+++ b/src/backends/php/gen_bindings/serde_defaults.rs
@@ -15,20 +15,33 @@ fn serde_default_path(default: Option<&str>) -> Option<&str> {
     (!path.is_empty()).then_some(path)
 }
 
-fn function_path_default_fn(field: &FieldDef) -> Option<(String, String)> {
+fn function_path_default_fn(field: &FieldDef, api: &ApiSurface) -> Option<(String, String)> {
     let path = serde_default_path(field.default.as_deref())?;
     let TypeRef::Named(type_name) = &field.ty else {
         return None;
     };
     let (_, function_name) = path.rsplit_once("::")?;
     // The `serde_defaults` module has no imports, so the type must be absolutely
-    // qualified. `type_rust_path` is already absolute (e.g. `core_crate::Policy`);
-    // when absent the type is the binding DTO at the crate root, so prefix `crate::`.
-    let qualified = match field.type_rust_path.as_deref() {
-        Some(path) => path.to_string(),
-        None => format!("crate::{type_name}"),
-    };
-    Some((qualified.clone(), format!("{qualified}::{function_name}()")))
+    // qualified. `type_rust_path` is the core type's absolute path (e.g.
+    // `core_crate::Policy`); when absent the type is itself a binding DTO at the
+    // crate root, whose default fn is an associated function we call directly.
+    //
+    // When the core type is *also* mirrored into a crate-root binding DTO, the
+    // field is rendered as the mirror (`crate::Policy`), not the core type — so the
+    // helper must return the mirror and convert the core value via `.into()` (the
+    // mirror derives `From<core>`). Returning the core type there mismatches the
+    // field type and fails to compile.
+    match field.type_rust_path.as_deref() {
+        Some(core_path) if api.types.iter().any(|typ| &typ.name == type_name) => Some((
+            format!("crate::{type_name}"),
+            format!("{core_path}::{function_name}().into()"),
+        )),
+        Some(core_path) => Some((core_path.to_string(), format!("{core_path}::{function_name}()"))),
+        None => Some((
+            format!("crate::{type_name}"),
+            format!("crate::{type_name}::{function_name}()"),
+        )),
+    }
 }
 
 fn typed_default_fn(default: &DefaultValue, ty: &TypeRef) -> Option<(&'static str, String)> {
@@ -85,7 +98,7 @@ pub(super) fn gen_serde_defaults_module(api: &ApiSurface) -> Option<String> {
         for field in typ.fields.iter().filter(|field| !field.optional) {
             let fn_name = serde_default_fn_name(&typ.name, &field.name);
 
-            if let Some((return_type, body)) = function_path_default_fn(field) {
+            if let Some((return_type, body)) = function_path_default_fn(field, api) {
                 functions.push(format!("    pub fn {fn_name}() -> {return_type} {{ {body} }}"));
                 continue;
             }
@@ -103,5 +116,75 @@ pub(super) fn gen_serde_defaults_module(api: &ApiSurface) -> Option<String> {
         None
     } else {
         Some(format!("mod serde_defaults {{\n{}\n}}", functions.join("\n")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::ir::TypeDef;
+
+    fn foreign_default_field(name: &str, type_name: &str, core_path: &str, default_fn: &str) -> FieldDef {
+        FieldDef {
+            name: name.to_string(),
+            ty: TypeRef::Named(type_name.to_string()),
+            optional: false,
+            default: Some(format!("serde(default = \"{default_fn}\")")),
+            type_rust_path: Some(core_path.to_string()),
+            ..Default::default()
+        }
+    }
+
+    fn config_with_field(field: FieldDef) -> TypeDef {
+        TypeDef {
+            name: "CrawlConfig".to_string(),
+            has_default: true,
+            fields: vec![field],
+            ..Default::default()
+        }
+    }
+
+    // A core type that is also mirrored into a crate-root DTO: the field renders as
+    // the mirror, so the helper must return the mirror and `.into()`-convert the core
+    // value. Regression for the crawlberg `SsrfPolicy` E0308.
+    #[test]
+    fn mirrored_core_type_default_returns_mirror_and_converts() {
+        let config = config_with_field(foreign_default_field(
+            "ssrf",
+            "SsrfPolicy",
+            "crawlberg::SsrfPolicy",
+            "crawlberg::SsrfPolicy::from_env",
+        ));
+        let mirror = TypeDef { name: "SsrfPolicy".to_string(), ..Default::default() };
+        let api = ApiSurface { types: vec![config, mirror], ..Default::default() };
+
+        let module = gen_serde_defaults_module(&api).expect("module generated");
+        assert!(
+            module.contains(
+                "pub fn crawl_config_ssrf() -> crate::SsrfPolicy { crawlberg::SsrfPolicy::from_env().into() }"
+            ),
+            "expected mirror return type with `.into()` conversion, got:\n{module}"
+        );
+    }
+
+    // The same core type used directly (no mirror DTO): return the core type as-is,
+    // no conversion.
+    #[test]
+    fn unmirrored_core_type_default_returns_core_type() {
+        let config = config_with_field(foreign_default_field(
+            "ssrf",
+            "SsrfPolicy",
+            "crawlberg::SsrfPolicy",
+            "crawlberg::SsrfPolicy::from_env",
+        ));
+        let api = ApiSurface { types: vec![config], ..Default::default() };
+
+        let module = gen_serde_defaults_module(&api).expect("module generated");
+        assert!(
+            module.contains(
+                "pub fn crawl_config_ssrf() -> crawlberg::SsrfPolicy { crawlberg::SsrfPolicy::from_env() }"
+            ),
+            "expected core return type without conversion, got:\n{module}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

The generated `xberg-php` crate stopped compiling after the crawlberg 1.0.1 bump:

```
error[E0308]: `match` arms have incompatible types
   |
   | #[serde(default = "crate::serde_defaults::crawl_config_ssrf")]
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `SsrfPolicy`, found `crawlberg::SsrfPolicy`
```

`gen_serde_defaults_module` (php backend) emits a helper fn for each `#[serde(default = "...")]` field. It built the helper's return type from the field's `type_rust_path` — the **core** type's path. For `CrawlConfig.ssrf`, whose default is `crawlberg::SsrfPolicy::from_env`, that produced:

```rust
pub fn crawl_config_ssrf() -> crawlberg::SsrfPolicy { crawlberg::SsrfPolicy::from_env() }
```

But alef also mirrors `SsrfPolicy` into a crate-root binding DTO, so the field is rendered as the mirror (`ssrf: SsrfPolicy`), not the core type. Return type vs. field type mismatch → E0308. The code assumed "has a core path ⇒ the field uses the core type directly", which is false for a core type that is also mirrored.

## Solution

When the core type is mirrored into a binding DTO (present in `api.types`), the helper now returns the crate-root mirror and converts the core value via `.into()` (the mirror derives `From<core>`):

```rust
pub fn crawl_config_ssrf() -> crate::SsrfPolicy { crawlberg::SsrfPolicy::from_env().into() }
```

Core types used directly (no mirror DTO) keep returning the core type as-is; crate-root binding DTOs with an associated default fn are unchanged.

Two unit tests cover the mirrored (return mirror + `.into()`) and unmirrored (return core type, no conversion) cases.

Fixes the `xberg-php` build break against crawlberg 1.0.1.
