### PR TITLE
feat(scaffold): honor per-target core-dependency overrides in the scripting bindings

### DIFF
--- a/schemas/alef.schema.json
+++ b/schemas/alef.schema.json
@@ -2215,6 +2215,14 @@
             "string",
             "null"
           ]
+        },
+        "target_dep_overrides": {
+          "default": [],
+          "description": "Per-target overrides for the core-crate dependency emitted into the\ngenerated `Cargo.toml`. See [`super::FfiConfig::target_dep_overrides`].",
+          "items": {
+            "$ref": "#/$defs/FfiTargetDepOverride"
+          },
+          "type": "array"
         }
       },
       "type": "object"
@@ -3793,6 +3801,14 @@
             "null"
           ]
         },
+        "target_dep_overrides": {
+          "default": [],
+          "description": "Per-target overrides for the core-crate dependency emitted into the\ngenerated `Cargo.toml`. See [`super::FfiConfig::target_dep_overrides`].",
+          "items": {
+            "$ref": "#/$defs/FfiTargetDepOverride"
+          },
+          "type": "array"
+        },
         "tokio_util_features": {
           "default": null,
           "description": "Features for the auto-emitted `tokio-util` dependency that backs napi trait-bridge\ncancellation tokens. Defaults to `[\"rt\"]` because `tokio_util::sync::CancellationToken`\nis gated behind the `rt` feature in tokio-util 0.7+. Override when a consumer needs\nadditional tokio-util features (e.g. `[\"rt\", \"codec\"]`).",
@@ -4328,6 +4344,14 @@
           ],
           "default": null,
           "description": "Output directory for generated PHP facade / stubs (e.g., `packages/php/src/`)."
+        },
+        "target_dep_overrides": {
+          "default": [],
+          "description": "Per-target overrides for the core-crate dependency emitted into the\ngenerated `Cargo.toml`. See [`super::FfiConfig::target_dep_overrides`].",
+          "items": {
+            "$ref": "#/$defs/FfiTargetDepOverride"
+          },
+          "type": "array"
         }
       },
       "type": "object"
@@ -4684,6 +4708,14 @@
               "type": "null"
             }
           ]
+        },
+        "target_dep_overrides": {
+          "default": [],
+          "description": "Per-target overrides for the core-crate dependency emitted into the\ngenerated `Cargo.toml`. Mirrors [`super::FfiConfig::target_dep_overrides`]:\nwhen non-empty, the core dependency is wrapped in\n`[target.'cfg(not(<any-cfg>))'.dependencies]` plus one\n`[target.'cfg(<cfg>)'.dependencies]` block per override, so a specific\ntarget can swap the core crate's feature set.",
+          "items": {
+            "$ref": "#/$defs/FfiTargetDepOverride"
+          },
+          "type": "array"
         }
       },
       "type": "object"
@@ -5652,6 +5684,14 @@
               "type": "null"
             }
           ]
+        },
+        "target_dep_overrides": {
+          "default": [],
+          "description": "Per-target overrides for the core-crate dependency emitted into the\ngenerated `Cargo.toml`. See [`super::FfiConfig::target_dep_overrides`].",
+          "items": {
+            "$ref": "#/$defs/FfiTargetDepOverride"
+          },
+          "type": "array"
         }
       },
       "type": "object"

--- a/src/core/config/languages/elixir.rs
+++ b/src/core/config/languages/elixir.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use super::FfiTargetDepOverride;
+
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct ElixirConfig {
     pub app_name: Option<String>,
@@ -55,4 +57,8 @@ pub struct ElixirConfig {
     /// `aarch64-apple-darwin, aarch64-unknown-linux-gnu, x86_64-unknown-linux-gnu, x86_64-pc-windows-gnu`.
     #[serde(default)]
     pub nif_targets: Vec<String>,
+    /// Per-target overrides for the core-crate dependency emitted into the
+    /// generated `Cargo.toml`. See [`super::FfiConfig::target_dep_overrides`].
+    #[serde(default)]
+    pub target_dep_overrides: Vec<FfiTargetDepOverride>,
 }

--- a/src/core/config/languages/node.rs
+++ b/src/core/config/languages/node.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use super::FfiTargetDepOverride;
+
 /// Configuration for a single capsule type entry in `NodeConfig::capsule_types`.
 ///
 /// When set, the named Rust type is NOT emitted as a `#[napi]` opaque wrapper.
@@ -125,4 +127,8 @@ pub struct NodeConfig {
     /// Extra paths to append to default lint commands (format, check, typecheck).
     #[serde(default)]
     pub extra_lint_paths: Vec<String>,
+    /// Per-target overrides for the core-crate dependency emitted into the
+    /// generated `Cargo.toml`. See [`super::FfiConfig::target_dep_overrides`].
+    #[serde(default)]
+    pub target_dep_overrides: Vec<FfiTargetDepOverride>,
 }

--- a/src/core/config/languages/php.rs
+++ b/src/core/config/languages/php.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use super::StubsConfig;
+use super::{FfiTargetDepOverride, StubsConfig};
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct PhpConfig {
@@ -62,4 +62,8 @@ pub struct PhpConfig {
     /// Extra paths to append to default lint commands (format, check, typecheck).
     #[serde(default)]
     pub extra_lint_paths: Vec<String>,
+    /// Per-target overrides for the core-crate dependency emitted into the
+    /// generated `Cargo.toml`. See [`super::FfiConfig::target_dep_overrides`].
+    #[serde(default)]
+    pub target_dep_overrides: Vec<FfiTargetDepOverride>,
 }

--- a/src/core/config/languages/python.rs
+++ b/src/core/config/languages/python.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use super::StubsConfig;
+use super::{FfiTargetDepOverride, StubsConfig};
 
 /// Configuration for a single capsule type entry in `PythonConfig::capsule_types`.
 ///
@@ -143,4 +143,12 @@ pub struct PythonConfig {
     /// `ExtractionResult` instead of `_rust.ExtractionResult`.
     #[serde(default)]
     pub reexported_types: Vec<String>,
+    /// Per-target overrides for the core-crate dependency emitted into the
+    /// generated `Cargo.toml`. Mirrors [`super::FfiConfig::target_dep_overrides`]:
+    /// when non-empty, the core dependency is wrapped in
+    /// `[target.'cfg(not(<any-cfg>))'.dependencies]` plus one
+    /// `[target.'cfg(<cfg>)'.dependencies]` block per override, so a specific
+    /// target can swap the core crate's feature set.
+    #[serde(default)]
+    pub target_dep_overrides: Vec<FfiTargetDepOverride>,
 }

--- a/src/core/config/languages/ruby.rs
+++ b/src/core/config/languages/ruby.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use super::StubsConfig;
+use super::{FfiTargetDepOverride, StubsConfig};
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct RubyConfig {
@@ -41,4 +41,8 @@ pub struct RubyConfig {
     /// Extra paths to append to default lint commands (format, check, typecheck).
     #[serde(default)]
     pub extra_lint_paths: Vec<String>,
+    /// Per-target overrides for the core-crate dependency emitted into the
+    /// generated `Cargo.toml`. See [`super::FfiConfig::target_dep_overrides`].
+    #[serde(default)]
+    pub target_dep_overrides: Vec<FfiTargetDepOverride>,
 }

--- a/src/scaffold/languages/elixir.rs
+++ b/src/scaffold/languages/elixir.rs
@@ -66,13 +66,24 @@ pub(crate) fn scaffold_elixir_cargo(
     // Collect all [dependencies] entries then sort alphabetically so the emitted
     // Cargo.toml is cargo-sort canonical without a post-processing step.
     let features_str = core_dep_features(config, Language::Elixir);
+    let core_overrides = config
+        .elixir
+        .as_ref()
+        .map(|c| c.target_dep_overrides.as_slice())
+        .unwrap_or(&[]);
+    let (core_dep_line, core_target_blocks) = crate::scaffold::render_core_dep_with_overrides(
+        &config.name,
+        &format!("../../../../crates/{core_crate_dir}"),
+        &features_str,
+        version,
+        core_overrides,
+    );
+    let core_target_blocks_section = if core_target_blocks.is_empty() {
+        String::new()
+    } else {
+        format!("\n{core_target_blocks}")
+    };
     let mut dep_lines: Vec<String> = vec![
-        crate::scaffold::render_core_dep(
-            &config.name,
-            &format!("../../../../crates/{core_crate_dir}"),
-            &features_str,
-            version,
-        ),
         format!("rustler = \"{}\"", tv::cargo::RUSTLER),
         "serde = { version = \"1\", features = [\"derive\"] }".to_owned(),
         "serde_json = \"1\"".to_owned(),
@@ -108,6 +119,9 @@ pub(crate) fn scaffold_elixir_cargo(
     dep_lines.push("alloc-no-stdlib = \"=2.0.4\"".to_owned());
     dep_lines.push("alloc-stdlib = \"=0.2.2\"".to_owned());
     dep_lines.push("brotli-decompressor = \"=5.0.1\"".to_owned());
+    if !core_dep_line.is_empty() {
+        dep_lines.push(core_dep_line);
+    }
     dep_lines.sort();
     let deps_section = dep_lines.join("\n");
 
@@ -232,7 +246,7 @@ name = "{nif_name}"
 crate-type = ["cdylib"]
 
 {features_table}[dependencies]
-{deps_section}{check_cfg_block}"#,
+{deps_section}{core_target_blocks_section}{check_cfg_block}"#,
         pkg_header = pkg_header,
         machete_section = machete_section,
         nif_name = nif_name,
@@ -240,6 +254,7 @@ crate-type = ["cdylib"]
         features_table = features_table,
         check_cfg_block = check_cfg_block,
         deps_section = deps_section,
+        core_target_blocks_section = core_target_blocks_section,
     );
 
     Ok(vec![GeneratedFile {

--- a/src/scaffold/languages/node.rs
+++ b/src/scaffold/languages/node.rs
@@ -221,12 +221,23 @@ pub(crate) fn scaffold_node_cargo(
     // Build [dependencies] block alphabetically sorted to match cargo-sort.
     // Order: async-trait?, futures-util?, <core-crate>, napi,
     // napi-derive, serde, serde_json, + any extra deps.
-    let core_dep = crate::scaffold::render_core_dep(
+    let core_overrides = config
+        .node
+        .as_ref()
+        .map(|c| c.target_dep_overrides.as_slice())
+        .unwrap_or(&[]);
+    let (core_dep, core_target_blocks) = crate::scaffold::render_core_dep_with_overrides(
         &config.name,
         &format!("../{core_crate_dir}"),
         &core_dep_features(config, Language::Node),
         version,
+        core_overrides,
     );
+    let core_target_blocks_section = if core_target_blocks.is_empty() {
+        String::new()
+    } else {
+        format!("{core_target_blocks}\n")
+    };
     let mut dep_entries: Vec<String> = vec![
         format!(
             "napi = {{ version = \"{napi}\", features = [{napi_features_str}] }}",
@@ -288,12 +299,13 @@ crate-type = ["cdylib"]
 {features_table}[dependencies]
 {dep_block}
 
-[build-dependencies]
+{core_target_blocks_section}[build-dependencies]
 napi-build = "{napi_build}"
 
 "#,
         pkg_header = pkg_header,
         dep_block = dep_block,
+        core_target_blocks_section = core_target_blocks_section,
         features_table = features_table,
         machete_ignored_str = machete_ignored_str,
         napi_build = tv::cargo::NAPI_BUILD,

--- a/src/scaffold/languages/php.rs
+++ b/src/scaffold/languages/php.rs
@@ -75,12 +75,23 @@ pub(crate) fn scaffold_php_cargo(api: &ApiSurface, config: &ResolvedCrateConfig)
     // Build [dependencies] block alphabetically sorted to match cargo-sort.
     // Order: async-trait?, ext-php-rs, futures-util?, <core-crate>,
     // serde, serde_json, tokio.
-    let core_dep_php = crate::scaffold::render_core_dep(
+    let core_overrides = config
+        .php
+        .as_ref()
+        .map(|c| c.target_dep_overrides.as_slice())
+        .unwrap_or(&[]);
+    let (core_dep_php, core_target_blocks) = crate::scaffold::render_core_dep_with_overrides(
         &config.name,
         &format!("../{core_crate_dir}"),
         &core_dep_features(config, Language::Php),
         version,
+        core_overrides,
     );
+    let core_target_blocks_section = if core_target_blocks.is_empty() {
+        String::new()
+    } else {
+        format!("\n{core_target_blocks}")
+    };
     let mut dep_entries: Vec<String> = vec![
         format!("ext-php-rs = \"{}\"", tv::cargo::EXT_PHP_RS),
         "serde = { version = \"1\", features = [\"derive\"] }".to_string(),
@@ -139,10 +150,11 @@ extension-module = []
 {cfg_forwarding}
 [dependencies]
 {dep_block}
-
+{core_target_blocks_section}
 "#,
         pkg_header = pkg_header,
         dep_block = dep_block,
+        core_target_blocks_section = core_target_blocks_section,
         machete_ignored_str = machete_ignored_str,
         cfg_forwarding = cfg_forwarding,
     );

--- a/src/scaffold/languages/python.rs
+++ b/src/scaffold/languages/python.rs
@@ -157,12 +157,25 @@ pub(crate) fn scaffold_python_cargo(
         .collect::<Vec<_>>()
         .join(", ");
     // Build [dependencies] block alphabetically sorted to match cargo-sort.
-    let core_dep_py = crate::scaffold::render_core_dep(
+    // When target_dep_overrides are configured, the core dep moves into
+    // `[target.'cfg(...)'.dependencies]` blocks (core_dep_py is then empty).
+    let core_overrides = config
+        .python
+        .as_ref()
+        .map(|p| p.target_dep_overrides.as_slice())
+        .unwrap_or(&[]);
+    let (core_dep_py, core_target_blocks) = crate::scaffold::render_core_dep_with_overrides(
         &config.name,
         &format!("../{core_crate_dir}"),
         &core_dep_features(config, Language::Python),
         version,
+        core_overrides,
     );
+    let core_target_blocks_section = if core_target_blocks.is_empty() {
+        String::new()
+    } else {
+        format!("\n{core_target_blocks}")
+    };
     let mut dep_entries: Vec<String> = vec![
         format!("pyo3 = {{ version = \"{}\" }}", tv::cargo::PYO3),
         format!(
@@ -207,11 +220,12 @@ extension-module = ["pyo3/extension-module", "pyo3/abi3-py310"]
 
 [dependencies]
 {dep_block}
-
+{core_target_blocks_section}
 "#,
         pkg_header = pkg_header,
         module_name = module_name,
         dep_block = dep_block,
+        core_target_blocks_section = core_target_blocks_section,
         machete_ignored_str = machete_ignored_str,
     );
 

--- a/src/scaffold/languages/ruby.rs
+++ b/src/scaffold/languages/ruby.rs
@@ -39,13 +39,24 @@ pub(crate) fn scaffold_ruby_cargo(
     // Collect all [dependencies] entries then sort alphabetically so the emitted
     // Cargo.toml is cargo-sort canonical without a post-processing step.
     let features_str = core_dep_features(config, Language::Ruby);
+    let core_overrides = config
+        .ruby
+        .as_ref()
+        .map(|c| c.target_dep_overrides.as_slice())
+        .unwrap_or(&[]);
+    let (core_dep_line, core_target_blocks) = crate::scaffold::render_core_dep_with_overrides(
+        &config.name,
+        &format!("../../../../../crates/{core_crate_dir}"),
+        &features_str,
+        version,
+        core_overrides,
+    );
+    let core_target_blocks_section = if core_target_blocks.is_empty() {
+        String::new()
+    } else {
+        format!("\n{core_target_blocks}")
+    };
     let mut dep_lines: Vec<String> = vec![
-        crate::scaffold::render_core_dep(
-            &config.name,
-            &format!("../../../../../crates/{core_crate_dir}"),
-            &features_str,
-            version,
-        ),
         format!("magnus = \"{}\"", tv::cargo::MAGNUS),
         // rb-sys 0.9.128 ships a mingw cross sysroot whose Ruby 4.0.2
         // `<ruby/defines.h>` pulls `<sys/select.h>`, which clang cannot find
@@ -79,6 +90,9 @@ pub(crate) fn scaffold_ruby_cargo(
         {
             dep_lines.push(trimmed.to_owned());
         }
+    }
+    if !core_dep_line.is_empty() {
+        dep_lines.push(core_dep_line);
     }
     dep_lines.sort();
     let deps_section = dep_lines.join("\n");
@@ -130,12 +144,13 @@ path = "../src/lib.rs"
 crate-type = ["cdylib"]
 
 {features_table}[dependencies]
-{deps_section}"#,
+{deps_section}{core_target_blocks_section}"#,
         pkg_header = pkg_header,
         machete_section = machete_section,
         lib_name = lib_name,
         features_table = features_table,
         deps_section = deps_section,
+        core_target_blocks_section = core_target_blocks_section,
     );
 
     Ok(vec![GeneratedFile {

--- a/src/scaffold/mod.rs
+++ b/src/scaffold/mod.rs
@@ -155,6 +155,60 @@ pub(crate) fn render_core_dep(crate_name: &str, rel_path: &str, features: &str, 
     }
 }
 
+/// Like [`render_core_dep`] but honours per-target overrides, mirroring the
+/// FFI/Dart backends. Returns `(core_dep_line, target_blocks)`:
+///
+/// - with no overrides, `core_dep_line` is the single `[dependencies]` line and
+///   `target_blocks` is empty (behaviour identical to [`render_core_dep`]);
+/// - with overrides, `core_dep_line` is empty and `target_blocks` holds a
+///   `[target.'cfg(not(any(<cfg…>)))'.dependencies]` default block plus one
+///   `[target.'cfg(<cfg>)'.dependencies]` block per override.
+///
+/// `default_features` is the pre-formatted feature suffix (e.g. `, features =
+/// ["a", "b"]` or `""`), matching [`render_core_dep`]. Callers place
+/// `core_dep_line` inside `[dependencies]` when non-empty and append
+/// `target_blocks` after that table.
+pub(crate) fn render_core_dep_with_overrides(
+    crate_name: &str,
+    rel_path: &str,
+    default_features: &str,
+    version: &str,
+    overrides: &[crate::core::config::FfiTargetDepOverride],
+) -> (String, String) {
+    if overrides.is_empty() {
+        return (
+            render_core_dep(crate_name, rel_path, default_features, version),
+            String::new(),
+        );
+    }
+
+    let combined_cfg = if overrides.len() == 1 {
+        overrides[0].cfg.clone()
+    } else {
+        let cfgs: Vec<String> = overrides.iter().map(|o| o.cfg.clone()).collect();
+        format!("any({})", cfgs.join(", "))
+    };
+
+    let mut blocks = format!(
+        "[target.'cfg(not({combined_cfg}))'.dependencies]\n{}\n",
+        render_core_dep(crate_name, rel_path, default_features, version)
+    );
+    for override_ in overrides {
+        let feats = if override_.features.is_empty() {
+            String::new()
+        } else {
+            let quoted: Vec<String> = override_.features.iter().map(|f| format!("\"{f}\"")).collect();
+            format!(", features = [{}]", quoted.join(", "))
+        };
+        blocks.push_str(&format!(
+            "\n[target.'cfg({})'.dependencies]\n{}\n",
+            override_.cfg,
+            render_core_dep(crate_name, rel_path, &feats, version)
+        ));
+    }
+    (String::new(), blocks)
+}
+
 ///
 /// Merges crate-level `extra_dependencies` with per-language overrides via
 /// `extra_deps_for_language`, then serializes each entry as a TOML line suitable

--- a/src/scaffold/tests/core_deps.rs
+++ b/src/scaffold/tests/core_deps.rs
@@ -194,3 +194,111 @@ fn test_scaffold_dev_path_build_form_preserved() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// target_dep_overrides for the scripting backends (python/node/ruby/php/elixir).
+//
+// Mirrors the FFI/Dart backends: when overrides are configured, the core
+// dependency moves out of `[dependencies]` into a `cfg(not(...))` default block
+// plus one `[target.'cfg(<cfg>)'.dependencies]` block per override.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn render_core_dep_with_overrides_no_overrides_matches_plain() {
+    let (line, blocks) = render_core_dep_with_overrides("my-lib", "../my-lib", ", features = [\"full\"]", "1.2.3", &[]);
+    assert_eq!(
+        line,
+        r#"my-lib = { version = "1.2.3", path = "../my-lib", features = ["full"] }"#
+    );
+    assert!(blocks.is_empty(), "no overrides must produce no target blocks");
+}
+
+#[test]
+fn render_core_dep_with_overrides_emits_default_and_override_blocks() {
+    let overrides = vec![crate::core::config::FfiTargetDepOverride {
+        cfg: "all(target_os = \"macos\", target_arch = \"x86_64\")".to_string(),
+        features: vec!["macos-intel-target".to_string()],
+    }];
+    let (line, blocks) =
+        render_core_dep_with_overrides("my-lib", "../my-lib", ", features = [\"full\"]", "1.2.3", &overrides);
+    assert!(line.is_empty(), "with overrides the core dep moves into target blocks");
+    assert!(
+        blocks.contains(r#"[target.'cfg(not(all(target_os = "macos", target_arch = "x86_64")))'.dependencies]"#),
+        "default block gated on the negated cfg:\n{blocks}"
+    );
+    assert!(
+        blocks.contains(r#"features = ["full"]"#),
+        "default block keeps the base features:\n{blocks}"
+    );
+    assert!(
+        blocks.contains(r#"[target.'cfg(all(target_os = "macos", target_arch = "x86_64"))'.dependencies]"#),
+        "override block gated on the cfg:\n{blocks}"
+    );
+    assert!(
+        blocks.contains(r#"features = ["macos-intel-target"]"#),
+        "override block uses the override features:\n{blocks}"
+    );
+}
+
+#[test]
+fn scripting_backends_emit_target_dep_override_blocks() {
+    let override_for = |lang: &str| {
+        format!(
+            "\n[[crates.{lang}.target_dep_overrides]]\ncfg = 'all(target_os = \"macos\", target_arch = \"x86_64\")'\nfeatures = [\"macos-intel-target\"]\n"
+        )
+    };
+    let overrides: String = ["python", "node", "ruby", "php", "elixir"]
+        .iter()
+        .map(|l| override_for(l))
+        .collect();
+    let toml = format!(
+        r#"
+[workspace]
+languages = ["python", "node", "ruby", "php", "elixir"]
+
+[[crates]]
+name = "my-lib"
+sources = ["src/lib.rs"]
+features = ["full"]
+
+[crates.scaffold]
+description = "Test library"
+license = "MIT"
+repository = "https://github.com/test/my-lib"
+authors = ["Alice"]
+keywords = ["test"]
+{overrides}"#
+    );
+    let cfg: crate::core::config::new_config::NewAlefConfig =
+        toml::from_str(&toml).expect("override config must parse");
+    let config = cfg.resolve().expect("override config must resolve").remove(0);
+    let api = test_api();
+
+    for lang in [
+        Language::Python,
+        Language::Node,
+        Language::Ruby,
+        Language::Php,
+        Language::Elixir,
+    ] {
+        let all_files = scaffold(&api, &config, &[lang]).unwrap();
+        let content = language_files(&all_files)
+            .iter()
+            .find(|f| f.path.ends_with("Cargo.toml") && f.content.contains("[target.'cfg"))
+            .map(|f| f.content.clone())
+            .unwrap_or_else(|| panic!("no target-gated Cargo.toml emitted for {lang:?}"));
+
+        assert!(
+            content.contains(r#"[target.'cfg(not(all(target_os = "macos", target_arch = "x86_64")))'.dependencies]"#),
+            "{lang:?} must gate the default core dep:\n{content}"
+        );
+        assert!(
+            content.contains(r#"[target.'cfg(all(target_os = "macos", target_arch = "x86_64"))'.dependencies]"#),
+            "{lang:?} must emit the override block:\n{content}"
+        );
+        assert!(
+            content.contains(r#"features = ["macos-intel-target"]"#),
+            "{lang:?} override must use the override features:\n{content}"
+        );
+    }
+}

--- a/src/scaffold/tests/extra_deps.rs
+++ b/src/scaffold/tests/extra_deps.rs
@@ -177,6 +177,7 @@ fn test_scaffold_language_level_extra_deps_override_crate_level() {
         extra_lint_paths: Vec::new(),
         extra_init_imports: std::collections::BTreeMap::new(),
         reexported_types: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
     let rendered = render_extra_deps(&config, Language::Python);
     // Python-level "2.0" should win over crate-level "1.0"

--- a/src/scaffold/tests/language_elixir.rs
+++ b/src/scaffold/tests/language_elixir.rs
@@ -257,6 +257,7 @@ fn test_scaffold_elixir_trait_bridge_module_name_is_pascal_case_for_hyphenated_c
         extra_lint_paths: Vec::new(),
         cpu_bound_functions: Vec::new(),
         nif_targets: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
     config.trait_bridges = vec![TraitBridgeConfig {
         trait_name: "HtmlVisitor".to_string(),
@@ -319,6 +320,7 @@ fn test_scaffold_elixir_trait_bridge_registers_genserver_pid_and_plugin_name() {
         extra_lint_paths: Vec::new(),
         cpu_bound_functions: Vec::new(),
         nif_targets: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
     config.trait_bridges = vec![TraitBridgeConfig {
         trait_name: "OcrBackend".to_string(),
@@ -384,6 +386,7 @@ fn test_scaffold_elixir_trait_bridge_module_name_is_pascal_case_for_multi_word_c
         extra_lint_paths: Vec::new(),
         cpu_bound_functions: Vec::new(),
         nif_targets: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
     config.trait_bridges = vec![TraitBridgeConfig {
         trait_name: "Parser".to_string(),

--- a/tests/backends_napi_gen_bindings_test.rs
+++ b/tests/backends_napi_gen_bindings_test.rs
@@ -2218,6 +2218,7 @@ package_name = "test-lib"
         run_wrapper: None,
         extra_lint_paths: vec![],
         crate_dir: None,
+        target_dep_overrides: Vec::new(),
     });
     resolved
 }

--- a/tests/backends_pyo3_gen_bindings/alef44_api.rs
+++ b/tests/backends_pyo3_gen_bindings/alef44_api.rs
@@ -260,6 +260,7 @@ fn test_api_py_uses_keyword_arguments() {
         extra_lint_paths: Vec::new(),
         extra_init_imports: std::collections::BTreeMap::new(),
         reexported_types: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
 
     let files = backend
@@ -366,6 +367,7 @@ fn test_async_function_emits_async_def_and_await() {
         extra_lint_paths: Vec::new(),
         extra_init_imports: std::collections::BTreeMap::new(),
         reexported_types: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
 
     let files = backend
@@ -473,6 +475,7 @@ fn test_trait_bridge_register_fns_in_api_py_and_all() {
         extra_lint_paths: Vec::new(),
         extra_init_imports: std::collections::BTreeMap::new(),
         reexported_types: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
     // Configure two trait bridges with register_fn
     config.trait_bridges = vec![

--- a/tests/backends_pyo3_gen_bindings/capsule_types.rs
+++ b/tests/backends_pyo3_gen_bindings/capsule_types.rs
@@ -203,6 +203,7 @@ fn test_capsule_types_end_to_end() {
         extra_lint_paths: Vec::new(),
         extra_init_imports: std::collections::BTreeMap::new(),
         reexported_types: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
 
     let files = backend
@@ -494,6 +495,7 @@ fn test_capsule_types_in_methods() {
         extra_lint_paths: Vec::new(),
         extra_init_imports: std::collections::BTreeMap::new(),
         reexported_types: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
 
     let files = backend

--- a/tests/backends_pyo3_gen_bindings/enum_options_regressions.rs
+++ b/tests/backends_pyo3_gen_bindings/enum_options_regressions.rs
@@ -309,6 +309,7 @@ fn test_api_py_void_function_no_redundant_return() {
         extra_lint_paths: Vec::new(),
         extra_init_imports: std::collections::BTreeMap::new(),
         reexported_types: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
 
     let files = backend
@@ -450,6 +451,7 @@ fn test_api_py_pep8_blank_lines_between_functions() {
         extra_lint_paths: Vec::new(),
         extra_init_imports: std::collections::BTreeMap::new(),
         reexported_types: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
 
     let files = backend

--- a/tests/backends_pyo3_gen_bindings/options_exports.rs
+++ b/tests/backends_pyo3_gen_bindings/options_exports.rs
@@ -141,6 +141,7 @@ fn test_return_type_exported_from_native_module_not_options() {
         extra_lint_paths: Vec::new(),
         extra_init_imports: std::collections::BTreeMap::new(),
         reexported_types: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
 
     let files = backend
@@ -412,6 +413,7 @@ fn test_api_py_imports_config_dto_with_self_returning_method_from_options() {
         extra_lint_paths: Vec::new(),
         extra_init_imports: std::collections::BTreeMap::new(),
         reexported_types: Vec::new(),
+        target_dep_overrides: Vec::new(),
     });
 
     let files = backend
@@ -581,6 +583,7 @@ fn test_typeddict_style_reexports_only_listed_results_as_native() {
         extra_lint_paths: Vec::new(),
         extra_init_imports: std::collections::BTreeMap::new(),
         reexported_types: vec!["DocResult".to_string()],
+        target_dep_overrides: Vec::new(),
     });
 
     let files = backend


### PR DESCRIPTION
Fixes #163.

## What this changes

alef generates a Rust crate for each language binding and writes its `Cargo.toml`. You can tell alef to build the core crate with different features on a specific platform, via `target_dep_overrides` in `alef.toml` — but until now only the **FFI, JNI, Dart, and Swift** bindings honored it. The **Python, Node, Ruby, PHP, and Elixir** bindings ignored it and always wrote a single, platform-independent core dependency.

This makes those five bindings honor it too.

**Before** — a Python binding's `Cargo.toml`, override silently ignored:

```toml
[dependencies]
core-lib = { version = "1.0", path = "…", features = ["full"] }
```

**After** — same binding, with an override configured for Intel macOS:

```toml
[target.'cfg(not(all(target_os = "macos", target_arch = "x86_64")))'.dependencies]
core-lib = { version = "1.0", path = "…", features = ["full"] }

[target.'cfg(all(target_os = "macos", target_arch = "x86_64"))'.dependencies]
core-lib = { version = "1.0", path = "…", features = ["macos-intel-target"] }
```

## How

The FFI backend already does exactly this, so the change is a straight port, not new design:

- moved the "split the core dependency into per-target sections" logic into a shared helper (`render_core_dep_with_overrides`);
- added the `target_dep_overrides` option to the Python/Node/Ruby/PHP/Elixir configs (reusing the FFI backend's `FfiTargetDepOverride`, as JNI already does), which regenerates the JSON schema;
- wired each of the five scaffolds to use the helper.

The override sets the *features* for the matched platform (same shape as FFI/JNI). The `default_features = false` variant that Dart/Swift also support is not included here — it can be a follow-up if needed.

## Verification

`cargo fmt --check` and `cargo check` are clean. New tests cover the helper directly and assert that all five bindings emit the per-platform sections. The full library test run adds no failures: `origin/main` is `4181 passed / 14 failed`, this branch is `4184 passed / 14 failed` — the same 14 pre-existing, environment-sensitive `test_scaffold_*` failures (they read the real workspace `Cargo.toml`), plus the 3 new passing tests.

Follow-up commit `ebcbaaa` extends the new config field to the struct literals in the `tests/` integration suites (`backends_pyo3_gen_bindings/*`, `backends_napi_gen_bindings_test.rs`), so `--all-targets` compiles cleanly — the `Validate` check is green as of that commit. The red `Test` / `poly-validate` checks reproduce identically on `main` (the 14 environment-sensitive failures above, and repo-wide `poly fmt` drift in files this PR doesn't touch).

