### PR TITLE
fix(trait-bridge): make generated bridges and host surfaces match the Rust trait contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (e.g. `supports_table_detection`, `process_document`) was silently ignored
   and the Rust default always won (#167).
 - **trait-bridge**: generated host surfaces (Python `Protocol`, Ruby `.rbs`,
-  PHP `interface`, Elixir behaviour, Java/Kotlin interfaces) now match the
-  runtime contract: Rust-defaulted methods are optional (or given
-  language-level defaults) instead of required, and the `Plugin` lifecycle
-  methods the bridge actually calls are part of the surface. Bridges treat a
-  missing `initialize`/`shutdown` as a no-op instead of failing registration.
-  On magnus the bridge no longer invokes `initialize` — which is the Ruby
-  constructor — on host objects (#166).
+  PHP `interface`, Elixir behaviour, Node `.d.ts`) now match the runtime
+  contract: Rust-defaulted methods are no longer required members (documented
+  as optional instead), Elixir behaviours gain `@optional_callbacks` plus the
+  lifecycle callbacks, and Node plugin interfaces declare the optional
+  lifecycle hooks. Bridges treat a missing `initialize`/`shutdown` as a no-op
+  instead of failing registration. On magnus the bridge no longer invokes
+  `initialize` — which is the Ruby constructor — on host objects (#166).
 - **pyo3**: plugin `Protocol` config parameters are now typed as the public
   options dataclass the package exports, and the bridge passes that type to
   the host, so an implementer typed against the public API conforms to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **trait-bridge**: dynamic-backend bridges (pyo3, magnus, php, napi, wasm,
+  rustler, extendr) now forward Rust-defaulted trait methods to the host
+  object when it implements them, falling back to the genuine Rust default
+  body otherwise. Previously a host implementation of a defaulted method
+  (e.g. `supports_table_detection`, `process_document`) was silently ignored
+  and the Rust default always won (#167).
+- **trait-bridge**: generated host surfaces (Python `Protocol`, Ruby `.rbs`,
+  PHP `interface`, Elixir behaviour, Java/Kotlin interfaces) now match the
+  runtime contract: Rust-defaulted methods are optional (or given
+  language-level defaults) instead of required, and the `Plugin` lifecycle
+  methods the bridge actually calls are part of the surface. Bridges treat a
+  missing `initialize`/`shutdown` as a no-op instead of failing registration.
+  On magnus the bridge no longer invokes `initialize` — which is the Ruby
+  constructor — on host objects (#166).
+- **pyo3**: plugin `Protocol` config parameters are now typed as the public
+  options dataclass the package exports, and the bridge passes that type to
+  the host, so an implementer typed against the public API conforms to the
+  Protocol (#165).
+- **rustler**: behaviour `@callback` specs now declare natively-marshalled
+  struct params as `map()` instead of the stale JSON `String.t()` (#168).
+
 ## [0.30.18] - 2026-07-03
 
 ### Added

--- a/src/backends/extendr/templates/bridge_constructor.jinja
+++ b/src/backends/extendr/templates/bridge_constructor.jinja
@@ -22,6 +22,9 @@ impl {{ wrapper }} {
         };
 
         Ok(Self {
+{% for method in optional_methods %}
+            has_{{ method }}: matches!(r_obj.dollar("{{ method }}"), Ok(v) if !v.is_null() && !v.is_na()),
+{% endfor %}
             inner: r_obj,
             cached_name,
         })

--- a/src/backends/extendr/trait_bridge.rs
+++ b/src/backends/extendr/trait_bridge.rs
@@ -77,14 +77,26 @@ impl TraitBridgeGenerator for ExtendrBridgeGenerator {
             .then(|| format!("self.has_{}", method.name))
     }
 
+    fn gen_lifecycle_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        // Same construction-time flag as trait methods: a host list without the
+        // function makes the lifecycle hook a no-op.
+        Some(format!("self.has_{}", method.name))
+    }
+
     fn extra_bridge_fields(&self, spec: &TraitBridgeSpec) -> Vec<(String, String)> {
         // Iterate the trait's method order (not the set) so field order is deterministic.
-        spec.trait_def
+        let mut fields: Vec<(String, String)> = spec
+            .trait_def
             .methods
             .iter()
             .filter(|m| self.forwardable_defaulted.contains(&m.name))
             .map(|m| (format!("has_{}", m.name), "bool".to_string()))
-            .collect()
+            .collect();
+        if spec.bridge_config.super_trait.is_some() {
+            fields.push(("has_initialize".to_string(), "bool".to_string()));
+            fields.push(("has_shutdown".to_string(), "bool".to_string()));
+        }
+        fields
     }
 
     fn bridge_imports(&self) -> Vec<String> {
@@ -313,13 +325,18 @@ impl TraitBridgeGenerator for ExtendrBridgeGenerator {
         let required_methods: Vec<String> = spec.required_methods().iter().map(|m| m.name.clone()).collect();
         // Presence flags for forwarded defaulted methods, captured once on the R
         // main thread. Trait method order keeps the emission deterministic.
-        let optional_methods: Vec<String> = spec
+        let mut optional_methods: Vec<String> = spec
             .trait_def
             .methods
             .iter()
             .filter(|m| self.forwardable_defaulted.contains(&m.name))
             .map(|m| m.name.clone())
             .collect();
+        // Lifecycle hooks are optional too; a missing function makes the hook a no-op.
+        if spec.bridge_config.super_trait.is_some() {
+            optional_methods.push("initialize".to_string());
+            optional_methods.push("shutdown".to_string());
+        }
 
         crate::backends::extendr::template_env::render(
             "bridge_constructor.jinja",

--- a/src/backends/extendr/trait_bridge.rs
+++ b/src/backends/extendr/trait_bridge.rs
@@ -34,6 +34,12 @@ pub struct ExtendrBridgeGenerator {
     /// to unwrap the host's native `ExternalPtr` and convert via `From<Binding>` (mirroring the
     /// options decoder), falling back to the `as_str()` + serde JSON-string path.
     pub struct_return_types: std::collections::HashSet<String>,
+    /// Rust-defaulted trait methods the bridge forwards to the host when the R
+    /// object provides them. Presence is cached as `has_<method>` bool fields at
+    /// construction (on the R main thread) because R objects cannot be probed
+    /// from worker threads. Methods absent here keep the trait's Rust default
+    /// unconditionally.
+    pub forwardable_defaulted: std::collections::HashSet<String>,
 }
 
 impl ExtendrBridgeGenerator {
@@ -61,6 +67,24 @@ impl ExtendrBridgeGenerator {
 impl TraitBridgeGenerator for ExtendrBridgeGenerator {
     fn foreign_object_type(&self) -> &str {
         "extendr_api::Robj"
+    }
+
+    fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        // The flag is captured at construction (see `gen_constructor`) because R
+        // objects can only be probed on the R main thread.
+        self.forwardable_defaulted
+            .contains(&method.name)
+            .then(|| format!("self.has_{}", method.name))
+    }
+
+    fn extra_bridge_fields(&self, spec: &TraitBridgeSpec) -> Vec<(String, String)> {
+        // Iterate the trait's method order (not the set) so field order is deterministic.
+        spec.trait_def
+            .methods
+            .iter()
+            .filter(|m| self.forwardable_defaulted.contains(&m.name))
+            .map(|m| (format!("has_{}", m.name), "bool".to_string()))
+            .collect()
     }
 
     fn bridge_imports(&self) -> Vec<String> {
@@ -287,12 +311,22 @@ impl TraitBridgeGenerator for ExtendrBridgeGenerator {
     fn gen_constructor(&self, spec: &TraitBridgeSpec) -> String {
         let wrapper = spec.wrapper_name();
         let required_methods: Vec<String> = spec.required_methods().iter().map(|m| m.name.clone()).collect();
+        // Presence flags for forwarded defaulted methods, captured once on the R
+        // main thread. Trait method order keeps the emission deterministic.
+        let optional_methods: Vec<String> = spec
+            .trait_def
+            .methods
+            .iter()
+            .filter(|m| self.forwardable_defaulted.contains(&m.name))
+            .map(|m| m.name.clone())
+            .collect();
 
         crate::backends::extendr::template_env::render(
             "bridge_constructor.jinja",
             minijinja::context! {
                 wrapper => wrapper,
                 required_methods => required_methods,
+                optional_methods => optional_methods,
             },
         )
     }
@@ -496,12 +530,17 @@ pub fn gen_trait_bridge(
         // `From<core::T>` conversion used for return values.
         let struct_param_types = native_marshalled_extendr_struct_params(trait_type, api);
         let struct_return_types = native_marshalled_extendr_struct_returns(trait_type, api);
+        // Rust-defaulted methods the bridge can forward to the host (host-defined
+        // implementations win; the Rust default runs otherwise).
+        let forwardable_defaulted =
+            crate::codegen::generators::trait_bridge::forwardable_defaulted_method_names(trait_type, api);
         let generator = ExtendrBridgeGenerator {
             core_import: core_import.to_string(),
             type_paths: type_paths.clone(),
             error_type: error_type.to_string(),
             struct_param_types,
             struct_return_types,
+            forwardable_defaulted,
         };
         let lifetime_type_names: std::collections::HashSet<String> = api
             .types

--- a/src/backends/extendr/trait_bridge/tests.rs
+++ b/src/backends/extendr/trait_bridge/tests.rs
@@ -86,6 +86,7 @@ fn generator_with(struct_params: &[&str]) -> ExtendrBridgeGenerator {
         error_type: "SampleError".to_string(),
         struct_param_types: struct_params.iter().map(|s| s.to_string()).collect(),
         struct_return_types: std::collections::HashSet::new(),
+        forwardable_defaulted: Default::default(),
     }
 }
 
@@ -179,6 +180,7 @@ fn native_struct_return_unwraps_external_ptr_before_json() {
         error_type: "SampleError".to_string(),
         struct_param_types: std::collections::HashSet::new(),
         struct_return_types: std::collections::HashSet::from(["Doc".to_string()]),
+        forwardable_defaulted: Default::default(),
     };
     let trait_def = greeter_trait_with(vec![]);
     let bridge_cfg = TraitBridgeConfig::default();

--- a/src/backends/magnus/gen_stubs.rs
+++ b/src/backends/magnus/gen_stubs.rs
@@ -165,7 +165,25 @@ fn gen_plugin_interface_stub(bridge: &TraitBridgeConfig, api: &ApiSurface) -> Op
     let interface_name = plugin_interface_name(&bridge.trait_name);
     let mut lines = vec![format!("  interface {interface_name}")];
 
-    for method in methods {
+    // Only the trait's non-defaulted methods are required at runtime: the bridge
+    // forwards Rust-defaulted methods when the host defines them (falling back to
+    // the Rust default otherwise), and the Plugin lifecycle hooks are no-ops when
+    // absent. RBS interfaces cannot express optional members, so the interface
+    // lists the required contract and a comment documents the optional surface.
+    let (required, optional): (Vec<&crate::core::ir::MethodDef>, Vec<&crate::core::ir::MethodDef>) =
+        methods.iter().partition(|m| !m.has_default_impl);
+    if !optional.is_empty() {
+        let names: Vec<&str> = optional.iter().map(|m| m.name.as_str()).collect();
+        lines.push(format!(
+            "    # Optional methods the bridge calls when the object defines them (the
+    # trait's Rust default behavior applies otherwise): {}.
+    # The lifecycle hooks `initialize`/`shutdown` are likewise optional (note:
+    # Ruby constructors are private and never count as the lifecycle hook).",
+            names.join(", ")
+        ));
+    }
+
+    for method in required {
         if method.binding_excluded {
             continue;
         }

--- a/src/backends/magnus/templates/trait_bridge_constructor.rs.jinja
+++ b/src/backends/magnus/templates/trait_bridge_constructor.rs.jinja
@@ -15,6 +15,9 @@ impl {{ wrapper }} {
         Ok(Self {
             inner: magnus::value::Opaque::from(rb_obj),
             cached_name: name,
+{%- for opt_method in optional_methods %}
+            has_{{ opt_method }}: rb_obj.respond_to("{{ opt_method }}", false).unwrap_or(false),
+{%- endfor %}
         })
     }
 }

--- a/src/backends/magnus/trait_bridge/bridge_generator.rs
+++ b/src/backends/magnus/trait_bridge/bridge_generator.rs
@@ -197,14 +197,28 @@ impl TraitBridgeGenerator for MagnusBridgeGenerator {
             .then(|| format!("self.has_{}", method.name))
     }
 
+    fn gen_lifecycle_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        // Same construction-time flag as trait methods. Note `respond_to(..., false)`
+        // excludes private methods, and Ruby constructors (`def initialize`) are
+        // private — so a host's constructor never counts as the plugin lifecycle
+        // hook and is never re-invoked at registration.
+        Some(format!("self.has_{}", method.name))
+    }
+
     fn extra_bridge_fields(&self, spec: &TraitBridgeSpec) -> Vec<(String, String)> {
         // Iterate the trait's method order (not the set) so field order is deterministic.
-        spec.trait_def
+        let mut fields: Vec<(String, String)> = spec
+            .trait_def
             .methods
             .iter()
             .filter(|m| self.forwardable_defaulted.contains(&m.name))
             .map(|m| (format!("has_{}", m.name), "bool".to_string()))
-            .collect()
+            .collect();
+        if spec.bridge_config.super_trait.is_some() {
+            fields.push(("has_initialize".to_string(), "bool".to_string()));
+            fields.push(("has_shutdown".to_string(), "bool".to_string()));
+        }
+        fields
     }
 
     fn bridge_imports(&self) -> Vec<String> {
@@ -357,13 +371,19 @@ let cached_name_for_blocking = cached_name.clone();\n\
         let required_methods: Vec<_> = spec.required_methods().iter().map(|m| m.name.as_str()).collect();
         // Presence flags for forwarded defaulted methods, captured once under the GVL.
         // Trait method order keeps the emission deterministic.
-        let optional_methods: Vec<_> = spec
+        let mut optional_methods: Vec<_> = spec
             .trait_def
             .methods
             .iter()
             .filter(|m| self.forwardable_defaulted.contains(&m.name))
             .map(|m| m.name.as_str())
             .collect();
+        // Lifecycle hooks are optional too; a missing (or private — Ruby
+        // constructors are private) method makes the hook a no-op.
+        if spec.bridge_config.super_trait.is_some() {
+            optional_methods.push("initialize");
+            optional_methods.push("shutdown");
+        }
 
         crate::backends::magnus::template_env::render(
             "trait_bridge_constructor.rs.jinja",

--- a/src/backends/magnus/trait_bridge/bridge_generator.rs
+++ b/src/backends/magnus/trait_bridge/bridge_generator.rs
@@ -83,6 +83,10 @@ pub fn gen_trait_bridge(
                 .into_iter()
                 .filter(|name| binding_to_core.contains(name.as_str()))
                 .collect();
+        // Rust-defaulted methods the bridge can forward to the host (host-defined
+        // implementations win; the Rust default runs otherwise).
+        let forwardable_defaulted =
+            crate::codegen::generators::trait_bridge::forwardable_defaulted_method_names(trait_type, api);
         let generator = MagnusBridgeGenerator {
             core_import: core_import.to_string(),
             type_paths: type_paths.clone(),
@@ -90,6 +94,7 @@ pub fn gen_trait_bridge(
             error_constructor: error_constructor.to_string(),
             struct_param_types,
             struct_return_types,
+            forwardable_defaulted,
         };
         let lifetime_type_names: std::collections::HashSet<String> = api
             .types
@@ -155,6 +160,12 @@ struct MagnusBridgeGenerator {
     /// the native wrapped object as well as a Hash/JSON via `to_json`) and converts via
     /// `From<Binding> for core`, instead of `serde_json::from_str` into core directly.
     struct_return_types: std::collections::HashSet<String>,
+    /// Rust-defaulted trait methods the bridge forwards to the host when the Ruby
+    /// object responds to them. Presence is cached as `has_<method>` bool fields at
+    /// construction (under the GVL) because async bridge bodies run on worker
+    /// threads where the Ruby object cannot be probed. Methods absent here keep
+    /// the trait's Rust default unconditionally.
+    forwardable_defaulted: std::collections::HashSet<String>,
 }
 
 impl MagnusBridgeGenerator {
@@ -176,6 +187,24 @@ impl MagnusBridgeGenerator {
 impl TraitBridgeGenerator for MagnusBridgeGenerator {
     fn foreign_object_type(&self) -> &str {
         "magnus::value::Opaque<magnus::Value>"
+    }
+
+    fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        // The flag is captured at construction (see `gen_constructor`) because the
+        // Ruby object cannot be probed off the GVL in async bridge bodies.
+        self.forwardable_defaulted
+            .contains(&method.name)
+            .then(|| format!("self.has_{}", method.name))
+    }
+
+    fn extra_bridge_fields(&self, spec: &TraitBridgeSpec) -> Vec<(String, String)> {
+        // Iterate the trait's method order (not the set) so field order is deterministic.
+        spec.trait_def
+            .methods
+            .iter()
+            .filter(|m| self.forwardable_defaulted.contains(&m.name))
+            .map(|m| (format!("has_{}", m.name), "bool".to_string()))
+            .collect()
     }
 
     fn bridge_imports(&self) -> Vec<String> {
@@ -326,12 +355,22 @@ let cached_name_for_blocking = cached_name.clone();\n\
     fn gen_constructor(&self, spec: &TraitBridgeSpec) -> String {
         let wrapper = spec.wrapper_name();
         let required_methods: Vec<_> = spec.required_methods().iter().map(|m| m.name.as_str()).collect();
+        // Presence flags for forwarded defaulted methods, captured once under the GVL.
+        // Trait method order keeps the emission deterministic.
+        let optional_methods: Vec<_> = spec
+            .trait_def
+            .methods
+            .iter()
+            .filter(|m| self.forwardable_defaulted.contains(&m.name))
+            .map(|m| m.name.as_str())
+            .collect();
 
         crate::backends::magnus::template_env::render(
             "trait_bridge_constructor.rs.jinja",
             minijinja::context! {
                 wrapper => wrapper,
                 required_methods => required_methods,
+                optional_methods => optional_methods,
             },
         )
     }
@@ -573,5 +612,101 @@ impl MagnusBridgeGenerator {
             ),
             _ => var.to_string(),
         }
+    }
+}
+
+#[cfg(test)]
+mod forwarding_tests {
+    use super::*;
+
+    fn make_generator() -> MagnusBridgeGenerator {
+        MagnusBridgeGenerator {
+            core_import: "sample_core".to_string(),
+            type_paths: HashMap::new(),
+            error_type: "SampleError".to_string(),
+            error_constructor: "SampleError::Message { message: {msg} }".to_string(),
+            struct_param_types: std::collections::HashSet::new(),
+            struct_return_types: std::collections::HashSet::new(),
+            forwardable_defaulted: std::collections::HashSet::new(),
+        }
+    }
+
+    fn make_trait() -> crate::core::ir::TypeDef {
+        crate::core::ir::TypeDef {
+            name: "OcrBackend".to_string(),
+            rust_path: "sample_core::OcrBackend".to_string(),
+            is_trait: true,
+            is_opaque: true,
+            methods: vec![
+                crate::core::ir::MethodDef {
+                    name: "supports_language".to_string(),
+                    receiver: Some(crate::core::ir::ReceiverKind::Ref),
+                    return_type: crate::core::ir::TypeRef::Primitive(crate::core::ir::PrimitiveType::Bool),
+                    ..Default::default()
+                },
+                crate::core::ir::MethodDef {
+                    name: "supports_table_detection".to_string(),
+                    has_default_impl: true,
+                    receiver: Some(crate::core::ir::ReceiverKind::Ref),
+                    return_type: crate::core::ir::TypeRef::Primitive(crate::core::ir::PrimitiveType::Bool),
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn presence_uses_construction_time_flag_and_wrapper_gains_field() {
+        let mut generator = make_generator();
+        generator
+            .forwardable_defaulted
+            .insert("supports_table_detection".to_string());
+        let trait_def = make_trait();
+        let bridge = crate::core::config::TraitBridgeConfig {
+            trait_name: "OcrBackend".to_string(),
+            ..crate::core::config::TraitBridgeConfig::default()
+        };
+        let spec = TraitBridgeSpec {
+            trait_def: &trait_def,
+            bridge_config: &bridge,
+            core_import: "sample_core",
+            wrapper_prefix: "Rb",
+            type_paths: HashMap::new(),
+            lifetime_type_names: std::collections::HashSet::new(),
+            error_type: "SampleError".to_string(),
+            error_constructor: "SampleError::Message { message: {msg} }".to_string(),
+        };
+
+        let check = generator
+            .gen_method_presence_check(&trait_def.methods[1], &spec)
+            .unwrap();
+        assert_eq!(check, "self.has_supports_table_detection");
+
+        let fields = generator.extra_bridge_fields(&spec);
+        assert_eq!(
+            fields,
+            vec![("has_supports_table_detection".to_string(), "bool".to_string())]
+        );
+
+        let ctor = generator.gen_constructor(&spec);
+        assert!(
+            ctor.contains("has_supports_table_detection: rb_obj.respond_to(\"supports_table_detection\", false)"),
+            "constructor must capture the flag under the GVL:\n{ctor}"
+        );
+
+        let output = crate::codegen::generators::trait_bridge::gen_bridge_all(&spec, &generator);
+        assert!(
+            output.code.contains("has_supports_table_detection: bool,"),
+            "wrapper struct must declare the flag field:\n{}",
+            output.code
+        );
+        assert!(
+            output
+                .code
+                .contains("RbOcrBackendBridgeDefaultSupportsTableDetection(self).supports_table_detection()"),
+            "fallback must run the Rust default via the delegate:\n{}",
+            output.code
+        );
     }
 }

--- a/src/backends/napi/gen_bindings/errors.rs
+++ b/src/backends/napi/gen_bindings/errors.rs
@@ -282,6 +282,11 @@ pub(super) fn gen_dts(
                 lines.push(format!("export interface {} {{", typ.name));
                 if trait_bridge_requires_plugin_name(typ, trait_bridges) {
                     lines.push("  name(): string".to_string());
+                    // Lifecycle hooks the bridge calls when present (no-op otherwise) —
+                    // part of the host surface so they are discoverable and type-checked.
+                    lines.push("  version?(): string".to_string());
+                    lines.push("  initialize?(): void".to_string());
+                    lines.push("  shutdown?(): void".to_string());
                 }
                 for method in &typ.methods {
                     let js_name = to_node_name(&method.name);

--- a/src/backends/napi/templates/napi_bridge_struct.jinja
+++ b/src/backends/napi/templates/napi_bridge_struct.jinja
@@ -9,7 +9,7 @@ pub struct {{ wrapper_name }} {
     obj_ref: std::sync::Mutex<Option<napi::bindgen_prelude::ObjectRef<false>>>,
     cached_name: String,
     cancellation_token: std::sync::Arc<tokio_util::sync::CancellationToken>,
-{%- for f in extra_fields %}
+{% for f in extra_fields %}
     {{ f.name }}: {{ f.ty }},
-{%- endfor %}
+{% endfor %}
 }

--- a/src/backends/napi/templates/napi_bridge_struct.jinja
+++ b/src/backends/napi/templates/napi_bridge_struct.jinja
@@ -9,4 +9,7 @@ pub struct {{ wrapper_name }} {
     obj_ref: std::sync::Mutex<Option<napi::bindgen_prelude::ObjectRef<false>>>,
     cached_name: String,
     cancellation_token: std::sync::Arc<tokio_util::sync::CancellationToken>,
+{%- for f in extra_fields %}
+    {{ f.name }}: {{ f.ty }},
+{%- endfor %}
 }

--- a/src/backends/napi/templates/trait_bridge_constructor.jinja
+++ b/src/backends/napi/templates/trait_bridge_constructor.jinja
@@ -57,6 +57,10 @@ impl {{ wrapper_name }} {
             obj_ref: std::sync::Mutex::new(Some(obj_ref)),
             cached_name,
             cancellation_token: std::sync::Arc::new(tokio_util::sync::CancellationToken::new()),
+{%- for method in optional_methods %}
+            has_{{ method.snake_case_name }}: js_obj.has_named_property("{{ method.name }}").unwrap_or(false)
+                || js_obj.has_named_property("{{ method.snake_case_name }}").unwrap_or(false),
+{%- endfor %}
         })
     }
 

--- a/src/backends/napi/trait_bridge/bridge.rs
+++ b/src/backends/napi/trait_bridge/bridge.rs
@@ -62,12 +62,17 @@ pub fn gen_trait_bridge(
         // same prefix the bridge uses for its wrapper struct and the binding's default node prefix.
         let struct_param_types =
             crate::codegen::generators::trait_bridge::native_marshalled_struct_params(trait_type, api);
+        // Rust-defaulted methods the bridge can forward to the host (host-defined
+        // implementations win; the Rust default runs otherwise).
+        let forwardable_defaulted =
+            crate::codegen::generators::trait_bridge::forwardable_defaulted_method_names(trait_type, api);
         let generator = NapiBridgeGenerator {
             core_import: core_import.to_string(),
             type_paths: type_paths.clone(),
             error_type: error_type.to_string(),
             struct_param_types,
             type_prefix: "Js".to_string(),
+            forwardable_defaulted,
         };
         let lifetime_type_names: std::collections::HashSet<String> = api
             .types
@@ -93,10 +98,16 @@ pub fn gen_trait_bridge(
 
         // Custom NAPI struct with cancellation_token field
         let wrapper_name = spec.wrapper_name();
+        let extra_fields: Vec<minijinja::Value> = generator
+            .extra_bridge_fields(&spec)
+            .into_iter()
+            .map(|(name, ty)| minijinja::context! { name => name, ty => ty })
+            .collect();
         code.push_str(&crate::backends::napi::template_env::render(
             "napi_bridge_struct.jinja",
             minijinja::context! {
                 wrapper_name => wrapper_name,
+                extra_fields => extra_fields,
             },
         ));
         code.push_str("\n\n");
@@ -119,6 +130,13 @@ pub fn gen_trait_bridge(
         code.push_str(&crate::codegen::generators::trait_bridge::gen_bridge_trait_impl(
             &spec, &generator,
         ));
+
+        // Default delegates — only when the generator forwards defaulted methods
+        let delegates = crate::codegen::generators::trait_bridge::gen_bridge_default_delegates(&spec, &generator);
+        if !delegates.is_empty() {
+            code.push_str("\n\n");
+            code.push_str(&delegates);
+        }
 
         // Registration function — only when register_fn is configured
         if let Some(reg_fn_code) =

--- a/src/backends/napi/trait_bridge/bridge_generator.rs
+++ b/src/backends/napi/trait_bridge/bridge_generator.rs
@@ -20,6 +20,12 @@ pub struct NapiBridgeGenerator {
     /// Enums, opaque/handle types, and excluded/unknown `Named` params are absent and keep their
     /// prior representation.
     pub struct_param_types: std::collections::HashSet<String>,
+    /// Rust-defaulted trait methods the bridge forwards to the host when the JS
+    /// object defines them. Presence is cached as `has_<method>` bool fields at
+    /// construction (on the JS thread) because async bridge bodies run off the
+    /// event loop where the object cannot be probed. Methods absent here keep
+    /// the trait's Rust default unconditionally.
+    pub forwardable_defaulted: std::collections::HashSet<String>,
     /// Node type-name prefix (e.g. `"Js"`) used to name the native DTO wrapper for a struct param
     /// (`Js{TypeName}`), matching the binding's emitted `#[napi(object)]` struct.
     pub type_prefix: String,
@@ -28,6 +34,24 @@ pub struct NapiBridgeGenerator {
 impl TraitBridgeGenerator for NapiBridgeGenerator {
     fn foreign_object_type(&self) -> &str {
         "napi::bindgen_prelude::Object<'static>"
+    }
+
+    fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        // The flag is captured at construction (see `gen_constructor`) because the
+        // JS object cannot be probed off the event-loop thread in async bodies.
+        self.forwardable_defaulted
+            .contains(&method.name)
+            .then(|| format!("self.has_{}", method.name))
+    }
+
+    fn extra_bridge_fields(&self, spec: &TraitBridgeSpec) -> Vec<(String, String)> {
+        // Iterate the trait's method order (not the set) so field order is deterministic.
+        spec.trait_def
+            .methods
+            .iter()
+            .filter(|m| self.forwardable_defaulted.contains(&m.name))
+            .map(|m| (format!("has_{}", m.name), "bool".to_string()))
+            .collect()
     }
 
     fn bridge_imports(&self) -> Vec<String> {
@@ -197,11 +221,28 @@ impl TraitBridgeGenerator for NapiBridgeGenerator {
             })
             .collect::<Vec<_>>();
 
+        // Presence flags for forwarded defaulted methods, captured once on the JS
+        // thread. Trait method order keeps the emission deterministic. Both the
+        // camelCase and snake_case property names count, matching method dispatch.
+        let optional_methods = spec
+            .trait_def
+            .methods
+            .iter()
+            .filter(|m| self.forwardable_defaulted.contains(&m.name))
+            .map(|m| {
+                minijinja::context! {
+                    name => to_camel_case(&m.name),
+                    snake_case_name => &m.name,
+                }
+            })
+            .collect::<Vec<_>>();
+
         crate::backends::napi::template_env::render(
             "trait_bridge_constructor.jinja",
             minijinja::context! {
                 wrapper_name => wrapper,
                 required_methods => required_methods,
+                optional_methods => optional_methods,
                 requires_plugin_name => spec.bridge_config.super_trait.is_some(),
             },
         )

--- a/src/backends/php/trait_bridge/generator.rs
+++ b/src/backends/php/trait_bridge/generator.rs
@@ -34,6 +34,10 @@ pub struct PhpBridgeGenerator {
     /// For such a return the bridge first extracts the host's native `#[php_class]` object via
     /// `FromZval` and converts via `From<Binding>`, falling back to the `val.string()` + serde path.
     pub struct_return_types: std::collections::HashSet<String>,
+    /// Rust-defaulted trait methods the bridge forwards to the host when the PHP
+    /// object's class defines them (per the shared `forwardable_defaulted_method_names`
+    /// rule). Methods absent here keep the trait's Rust default unconditionally.
+    pub forwardable_defaulted: std::collections::HashSet<String>,
 }
 
 impl PhpBridgeGenerator {
@@ -114,6 +118,15 @@ impl PhpBridgeGenerator {
 }
 
 impl TraitBridgeGenerator for PhpBridgeGenerator {
+    fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        self.forwardable_defaulted.contains(&method.name).then(|| {
+            format!(
+                "{{\n    // SAFETY: PHP objects are single-threaded; reads are safe within a request.\n    let __class = unsafe {{ (*self.inner).get_class_name().unwrap_or_default() }};\n    ext_php_rs::zend::Function::try_from_method(&__class, \"{}\").is_some()\n}}",
+                method.name
+            )
+        })
+    }
+
     fn foreign_object_type(&self) -> &str {
         "*mut ext_php_rs::types::ZendObject"
     }
@@ -340,12 +353,17 @@ pub fn gen_trait_bridge(
         // clones through the binding's `From<core::T>` counterpart before falling back to JSON.
         let struct_return_types =
             crate::codegen::generators::trait_bridge::native_marshalled_struct_returns(trait_type, api);
+        // Rust-defaulted methods the bridge can forward to the host (host-defined
+        // implementations win; the Rust default runs otherwise).
+        let forwardable_defaulted =
+            crate::codegen::generators::trait_bridge::forwardable_defaulted_method_names(trait_type, api);
         let generator = PhpBridgeGenerator {
             core_import: core_import.to_string(),
             type_paths: type_paths.clone(),
             error_type: error_type.to_string(),
             struct_param_types,
             struct_return_types,
+            forwardable_defaulted,
         };
         let lifetime_type_names: std::collections::HashSet<String> = api
             .types
@@ -364,5 +382,62 @@ pub fn gen_trait_bridge(
             error_constructor: error_constructor.to_string(),
         };
         gen_bridge_all(&spec, &generator)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presence_check_emitted_only_for_forwardable_defaulted_methods() {
+        let mut generator = PhpBridgeGenerator {
+            core_import: "sample_core".to_string(),
+            type_paths: HashMap::new(),
+            error_type: "SampleError".to_string(),
+            struct_param_types: std::collections::HashSet::new(),
+            struct_return_types: std::collections::HashSet::new(),
+            forwardable_defaulted: std::collections::HashSet::new(),
+        };
+        let trait_def = crate::core::ir::TypeDef {
+            name: "OcrBackend".to_string(),
+            rust_path: "sample_core::OcrBackend".to_string(),
+            is_trait: true,
+            is_opaque: true,
+            ..Default::default()
+        };
+        let bridge = crate::core::config::TraitBridgeConfig {
+            trait_name: "OcrBackend".to_string(),
+            ..crate::core::config::TraitBridgeConfig::default()
+        };
+        let spec = TraitBridgeSpec {
+            trait_def: &trait_def,
+            bridge_config: &bridge,
+            core_import: "sample_core",
+            wrapper_prefix: "Php",
+            type_paths: HashMap::new(),
+            lifetime_type_names: std::collections::HashSet::new(),
+            error_type: "SampleError".to_string(),
+            error_constructor: "SampleError::Message { message: {msg} }".to_string(),
+        };
+        let method = crate::core::ir::MethodDef {
+            name: "supports_table_detection".to_string(),
+            has_default_impl: true,
+            receiver: Some(crate::core::ir::ReceiverKind::Ref),
+            ..Default::default()
+        };
+        assert!(generator.gen_method_presence_check(&method, &spec).is_none());
+        generator
+            .forwardable_defaulted
+            .insert("supports_table_detection".to_string());
+        let check = generator.gen_method_presence_check(&method, &spec).unwrap();
+        assert!(
+            check.contains("Function::try_from_method"),
+            "php presence check must look the method up on the class: {check}"
+        );
+        assert!(
+            !check.contains("try_call_method"),
+            "presence must not invoke the method: {check}"
+        );
     }
 }

--- a/src/backends/php/trait_bridge/generator.rs
+++ b/src/backends/php/trait_bridge/generator.rs
@@ -118,6 +118,13 @@ impl PhpBridgeGenerator {
 }
 
 impl TraitBridgeGenerator for PhpBridgeGenerator {
+    fn gen_lifecycle_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        Some(format!(
+            "{{\n    // SAFETY: PHP objects are single-threaded; reads are safe within a request.\n    let __class = unsafe {{ (*self.inner).get_class_name().unwrap_or_default() }};\n    ext_php_rs::zend::Function::try_from_method(&__class, \"{}\").is_some()\n}}",
+            method.name
+        ))
+    }
+
     fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
         self.forwardable_defaulted.contains(&method.name).then(|| {
             format!(

--- a/src/backends/php/trait_bridge/interfaces.rs
+++ b/src/backends/php/trait_bridge/interfaces.rs
@@ -216,8 +216,26 @@ pub fn gen_registration_interface(
     ));
     out.push('\n');
 
-    // Generate each interface method (trait_type.methods already includes super-trait methods)
-    for method in &trait_type.methods {
+    // Only the trait's non-defaulted methods are required at runtime: the bridge
+    // forwards Rust-defaulted methods when the host class defines them (falling
+    // back to the Rust default otherwise), and the Plugin lifecycle hooks are
+    // no-ops when absent. A PHP `interface` member is a hard language requirement,
+    // so defaulted methods must not be interface members — they are documented in
+    // a comment instead.
+    let (required, optional): (Vec<&crate::core::ir::MethodDef>, Vec<&crate::core::ir::MethodDef>) =
+        trait_type.methods.iter().partition(|m| !m.has_default_impl);
+    if !optional.is_empty() {
+        let names: Vec<&str> = optional.iter().map(|m| m.name.as_str()).collect();
+        out.push_str(&format!(
+            "    // Optional methods the bridge calls when the class defines them (the
+    // trait's Rust default behavior applies otherwise): {}.
+    // The lifecycle hooks initialize()/shutdown() are likewise optional.
+",
+            names.join(", ")
+        ));
+    }
+
+    for method in required {
         let name = &method.name;
 
         // Build method signature parameters

--- a/src/backends/pyo3/gen_bindings/mod.rs
+++ b/src/backends/pyo3/gen_bindings/mod.rs
@@ -785,7 +785,6 @@ impl Backend for Pyo3Backend {
                         &config.error_type_name(),
                         &config.error_constructor_expr(),
                         api,
-                        &config.python_module_name(),
                         &reexported_types,
                     )?;
                     for imp in &bridge.imports {

--- a/src/backends/pyo3/gen_bindings/mod.rs
+++ b/src/backends/pyo3/gen_bindings/mod.rs
@@ -19,6 +19,7 @@ mod support_items;
 #[cfg(test)]
 mod tests;
 pub mod types;
+pub(in crate::backends::pyo3) use types::options_dataclass_type_names;
 pub(in crate::backends::pyo3) mod wire_schema;
 
 use crate::backends::pyo3::type_map::Pyo3Mapper;
@@ -762,6 +763,19 @@ impl Backend for Pyo3Backend {
             if opaque_types.is_empty() {
                 builder.add_import("std::sync::Arc");
             }
+            let reexported_types = config
+                .python
+                .as_ref()
+                .map(|c| c.reexported_types.clone())
+                .unwrap_or_default();
+            // One-time helper for lifting native callback params into the public
+            // options dataclasses (see Pyo3BridgeGenerator::options_lift_expr).
+            builder.add_item(&crate::backends::pyo3::template_env::render(
+                "trait_bridge/options_from_native_helper.jinja",
+                minijinja::context! {
+                    options_module => format!("{}.options", config.python_module_name()),
+                },
+            ));
             for bridge_cfg in &config.trait_bridges {
                 if let Some(trait_type) = api.types.iter().find(|t| t.is_trait && t.name == bridge_cfg.trait_name) {
                     let bridge = crate::backends::pyo3::trait_bridge::gen_trait_bridge(
@@ -771,6 +785,8 @@ impl Backend for Pyo3Backend {
                         &config.error_type_name(),
                         &config.error_constructor_expr(),
                         api,
+                        &config.python_module_name(),
+                        &reexported_types,
                     )?;
                     for imp in &bridge.imports {
                         builder.add_import(imp);

--- a/src/backends/pyo3/gen_bindings/types.rs
+++ b/src/backends/pyo3/gen_bindings/types.rs
@@ -29,6 +29,29 @@ fn to_python_enum_variant(name: &str) -> String {
 ///
 /// When `dto.python_output_style() == TypedDict` and a type has `is_return_type = true`,
 /// it is emitted as a `TypedDict` (with `total=False`) instead of a `@dataclass`.
+/// Names of the types `options.py` emits as `@dataclass` config DTOs: non-trait,
+/// `has_default`, not a return type, not an internal `*Update` type, and not
+/// re-exported as a native pyclass. This is the public *input* type family — the
+/// trait-callback marshalling and the Protocol stubs use the same set so the type
+/// a host is handed is the type the package exports under that name.
+pub(in crate::backends::pyo3) fn options_dataclass_type_names(
+    api: &ApiSurface,
+    reexported_types: &[String],
+) -> std::collections::HashSet<String> {
+    let reexported: AHashSet<&str> = reexported_types.iter().map(String::as_str).collect();
+    api.types
+        .iter()
+        .filter(|t| {
+            !t.is_trait
+                && t.has_default
+                && !t.is_return_type
+                && !t.name.ends_with("Update")
+                && !reexported.contains(t.name.as_str())
+        })
+        .map(|t| t.name.clone())
+        .collect()
+}
+
 pub(super) fn gen_options_py(
     api: &ApiSurface,
     module_name: &str,
@@ -496,7 +519,92 @@ pub(super) fn gen_options_py(
     // Data enums are imported from the native module and referenced by their class name in the
     // field annotations above — not redefined here as the old flattened union alias.
 
+    // Converters from the native pyclass to the public dataclass, one per emitted
+    // dataclass. The trait-callback bridges call these so a host method receives the
+    // same type the package publicly exports (the options dataclass), not the
+    // private native class.
+    out.push_str(&gen_from_native_converters(api, reexported_types));
+
     out
+}
+
+/// Emit `_from_native_<snake>(native)` module-level converters for every emitted
+/// options dataclass. Nested dataclass fields recurse (including through
+/// `Optional`/`Vec`/`Map` wrappers); every other field passes through unchanged —
+/// enums and re-exported types keep their single native identity.
+fn gen_from_native_converters(api: &ApiSurface, reexported_types: &[String]) -> String {
+    use heck::ToSnakeCase;
+    let options_types = options_dataclass_type_names(api, reexported_types);
+    let mut out = String::new();
+    let mut emitted: Vec<&crate::core::ir::TypeDef> =
+        api.types.iter().filter(|t| options_types.contains(&t.name)).collect();
+    emitted.sort_by(|a, b| a.name.cmp(&b.name));
+
+    for typ in emitted {
+        let fields: Vec<minijinja::Value> = typ
+            .fields
+            .iter()
+            .map(|f| {
+                let safe_name = crate::core::keywords::python_ident(&f.name);
+                let src = format!("native.{safe_name}");
+                minijinja::context! {
+                    name => &safe_name,
+                    expr => from_native_field_expr(&f.ty, &options_types, &src),
+                }
+            })
+            .collect();
+        out.push_str(&crate::backends::pyo3::template_env::render(
+            "trait_bridge/options_from_native.jinja",
+            minijinja::context! {
+                fn_name => format!("_from_native_{}", typ.name.to_snake_case()),
+                class_name => &typ.name,
+                fields => fields,
+            },
+        ));
+        out.push('\n');
+    }
+    out
+}
+
+/// Python expression converting one field value from the native object to the
+/// options-dataclass shape. Returns `src` unchanged when no conversion applies.
+fn from_native_field_expr(
+    ty: &crate::core::ir::TypeRef,
+    options_types: &std::collections::HashSet<String>,
+    src: &str,
+) -> String {
+    use crate::core::ir::TypeRef;
+    use heck::ToSnakeCase;
+    match ty {
+        TypeRef::Named(n) if options_types.contains(n) => {
+            format!("_from_native_{}({src})", n.to_snake_case())
+        }
+        TypeRef::Optional(inner) => {
+            let inner_expr = from_native_field_expr(inner, options_types, src);
+            if inner_expr == src {
+                src.to_string()
+            } else {
+                format!("(None if {src} is None else {inner_expr})")
+            }
+        }
+        TypeRef::Vec(inner) => {
+            let inner_expr = from_native_field_expr(inner, options_types, "__v");
+            if inner_expr == "__v" {
+                src.to_string()
+            } else {
+                format!("[{inner_expr} for __v in {src}]")
+            }
+        }
+        TypeRef::Map(_, value) => {
+            let value_expr = from_native_field_expr(value, options_types, "__val");
+            if value_expr == "__val" {
+                src.to_string()
+            } else {
+                format!("{{__k: {value_expr} for __k, __val in {src}.items()}}")
+            }
+        }
+        _ => src.to_string(),
+    }
 }
 
 pub(super) fn python_field_type(

--- a/src/backends/pyo3/gen_bindings/types.rs
+++ b/src/backends/pyo3/gen_bindings/types.rs
@@ -547,9 +547,18 @@ fn gen_from_native_converters(api: &ApiSurface, reexported_types: &[String]) -> 
             .map(|f| {
                 let safe_name = crate::core::keywords::python_ident(&f.name);
                 let src = format!("native.{safe_name}");
+                let inner_expr = from_native_field_expr(&f.ty, &options_types, &src);
+                // Fields are commonly `Named` + `optional: true` in the IR rather than
+                // `TypeRef::Optional` — a converting expression must still be None-guarded
+                // so a config with an absent nested section survives the lift.
+                let expr = if f.optional && inner_expr != src && !inner_expr.starts_with("(None if ") {
+                    format!("(None if {src} is None else {inner_expr})")
+                } else {
+                    inner_expr
+                };
                 minijinja::context! {
                     name => &safe_name,
-                    expr => from_native_field_expr(&f.ty, &options_types, &src),
+                    expr => expr,
                 }
             })
             .collect();

--- a/src/backends/pyo3/gen_stubs.rs
+++ b/src/backends/pyo3/gen_stubs.rs
@@ -244,13 +244,22 @@ pub fn gen_stubs(
     // Track the trait names that received a Protocol so the `register_*` signature below can type
     // its `backend` parameter against the Protocol instead of bare `object`.
     let mut protocol_trait_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // Config structs the package exports as options dataclasses: plugin-bridge
+    // callbacks receive the dataclass (the bridge lifts the native object), so the
+    // Protocol types those params as `options.X` — the publicly exported type.
+    let stub_reexported_types = config
+        .python
+        .as_ref()
+        .map(|c| c.reexported_types.clone())
+        .unwrap_or_default();
+    let options_types = crate::backends::pyo3::gen_bindings::options_dataclass_type_names(api, &stub_reexported_types);
     for bridge in trait_bridges {
         let is_protocol_bridge =
             bridge.bind_via == crate::core::config::BridgeBinding::OptionsField || bridge.register_fn.is_some();
         if !is_protocol_bridge {
             continue;
         }
-        if let Some(stub) = gen_visitor_protocol_stub(bridge, api, &capsule_names, emit_docstrings) {
+        if let Some(stub) = gen_visitor_protocol_stub(bridge, api, &capsule_names, emit_docstrings, &options_types) {
             body_lines.push(stub);
             body_lines.push("".to_string());
             protocol_trait_names.insert(bridge.trait_name.clone());

--- a/src/backends/pyo3/gen_stubs/protocol.rs
+++ b/src/backends/pyo3/gen_stubs/protocol.rs
@@ -19,6 +19,7 @@ pub(super) fn gen_visitor_protocol_stub(
     api: &ApiSurface,
     capsule_names: &std::collections::HashSet<&str>,
     emit_docstrings: bool,
+    options_types: &std::collections::HashSet<String>,
 ) -> Option<String> {
     let methods = bridge.resolve_methods(api);
     if methods.is_empty() {
@@ -98,10 +99,18 @@ pub(super) fn gen_visitor_protocol_stub(
         body_emitted = true;
         let mut params: Vec<String> = vec!["self".to_string()];
         for p in &method.params {
-            let param_type = substitute_capsule_type(
-                &python_type(&substitute_excluded_types(&p.ty, &excluded)),
-                capsule_names,
-            );
+            // Plugin-bridge callbacks receive options dataclasses for config structs
+            // (the runtime bridge lifts the native object), so type those params as
+            // the publicly exported `options.X`.
+            let param_type = match &p.ty {
+                crate::core::ir::TypeRef::Named(n) if is_plugin_bridge && options_types.contains(n) => {
+                    format!("options.{n}")
+                }
+                _ => substitute_capsule_type(
+                    &python_type(&substitute_excluded_types(&p.ty, &excluded)),
+                    capsule_names,
+                ),
+            };
             params.push(format!("{}: {}", p.name, param_type));
         }
         let return_type = substitute_capsule_type(

--- a/src/backends/pyo3/gen_stubs/protocol.rs
+++ b/src/backends/pyo3/gen_stubs/protocol.rs
@@ -26,6 +26,18 @@ pub(super) fn gen_visitor_protocol_stub(
     }
     let trait_def = api.types.iter().find(|t| t.name == bridge.trait_name)?;
 
+    // Plugin-style bridges (registered via `register_*`) only require the trait's
+    // non-defaulted methods at runtime — the bridge forwards Rust-defaulted methods
+    // when the host defines them and falls back to the Rust default otherwise, and
+    // the Plugin lifecycle hooks are no-ops when absent. Emitting defaulted methods
+    // as required Protocol members would reject every minimal (and valid) backend,
+    // so the Protocol lists the required contract and the docstring documents the
+    // optional surface. Visitor-style (options-field) bridges keep the full method
+    // list: their hosts are ad-hoc override maps, not registered plugin objects.
+    let is_plugin_bridge = bridge.register_fn.is_some();
+    let (required, optional): (Vec<&crate::core::ir::MethodDef>, Vec<&crate::core::ir::MethodDef>) =
+        methods.iter().partition(|m| !(is_plugin_bridge && m.has_default_impl));
+
     // Types excluded from the public binding surface are never emitted as `.pyi` classes; a
     // Protocol method referencing one (e.g. `-> InternalDocument`) would be an undefined name.
     // Substitute them with their JSON marshaling form, matching the runtime bridge.
@@ -38,10 +50,34 @@ pub(super) fn gen_visitor_protocol_stub(
 
     let mut lines = vec![format!("class {}(Protocol):", bridge.trait_name)];
 
-    if emit_docstrings {
-        if let Some(docstring) = pyi_docstring(&trait_def.doc, "    ") {
-            lines.push(docstring);
+    // The optional-methods note documents generated behavior that is otherwise
+    // invisible (the bridge forwards these when present), so it is emitted even
+    // when rustdoc-derived docstrings are disabled.
+    let mut doc = if emit_docstrings {
+        trait_def.doc.clone()
+    } else {
+        String::new()
+    };
+    if !optional.is_empty() {
+        let optional_list = optional
+            .iter()
+            .map(|m| format!("`{}`", python_safe_name(&m.name)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let lifecycle_note = if bridge.super_trait.is_some() {
+            " The lifecycle hooks `initialize()` and `shutdown()` (and `name()` / `version()`) are likewise optional."
+        } else {
+            ""
+        };
+        if !doc.is_empty() {
+            doc.push_str("\n\n");
         }
+        doc.push_str(&format!(
+            "Optional methods a backend may additionally implement — the bridge calls them when the object defines them, otherwise the trait's Rust default behavior applies: {optional_list}.{lifecycle_note}"
+        ));
+    }
+    if let Some(docstring) = pyi_docstring(&doc, "    ") {
+        lines.push(docstring);
     }
 
     // Each method becomes a Protocol method stub with `self` and the IR params.
@@ -55,7 +91,7 @@ pub(super) fn gen_visitor_protocol_stub(
     // never be awaited. The return type stays the native result type — the bridge now accepts
     // the binding's native object on return (with a mapping as fallback).
     let mut body_emitted = false;
-    for method in methods {
+    for method in required {
         if method.binding_excluded {
             continue;
         }

--- a/src/backends/pyo3/template_env.rs
+++ b/src/backends/pyo3/template_env.rs
@@ -23,6 +23,14 @@ static TEMPLATES: &[(&str, &str)] = &[
         include_str!("templates/trait_bridge/dataclass_field_with_default.jinja"),
     ),
     (
+        "trait_bridge/options_from_native.jinja",
+        include_str!("templates/trait_bridge/options_from_native.jinja"),
+    ),
+    (
+        "trait_bridge/options_from_native_helper.jinja",
+        include_str!("templates/trait_bridge/options_from_native_helper.jinja"),
+    ),
+    (
         "trait_bridge/indented_import_item.jinja",
         include_str!("templates/trait_bridge/indented_import_item.jinja"),
     ),

--- a/src/backends/pyo3/templates/trait_bridge/options_from_native.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/options_from_native.jinja
@@ -2,8 +2,8 @@
 def {{ fn_name }}(native: Any) -> {{ class_name }}:
     """Build the public `{{ class_name }}` dataclass from the native binding object."""
     return {{ class_name }}(
-{%- for f in fields %}
+{% for f in fields %}
         {{ f.name }}={{ f.expr }},
-{%- endfor %}
+{% endfor %}
     )
 

--- a/src/backends/pyo3/templates/trait_bridge/options_from_native.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/options_from_native.jinja
@@ -1,0 +1,9 @@
+
+def {{ fn_name }}(native: Any) -> {{ class_name }}:
+    """Build the public `{{ class_name }}` dataclass from the native binding object."""
+    return {{ class_name }}(
+{%- for f in fields %}
+        {{ f.name }}={{ f.expr }},
+{%- endfor %}
+    )
+

--- a/src/backends/pyo3/templates/trait_bridge/options_from_native_helper.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/options_from_native_helper.jinja
@@ -1,0 +1,18 @@
+/// Lift a native binding object into the package's public options dataclass via the
+/// generated `options._from_native_*` converter, so trait-callback hosts receive the
+/// type the package exports under that name. Falls back to the native object when the
+/// options module is unavailable (attribute access is identical either way).
+#[allow(dead_code)]
+fn __alef_options_from_native<'py, T>(py: Python<'py>, func: &str, native: T) -> pyo3::Py<pyo3::PyAny>
+where
+    T: pyo3::IntoPyObjectExt<'py>,
+{
+    let Ok(native) = pyo3::IntoPyObjectExt::into_py_any(native, py) else {
+        return py.None();
+    };
+    py.import("{{ options_module }}")
+        .and_then(|m| m.getattr(func))
+        .and_then(|f| f.call1((native.clone_ref(py),)))
+        .map(|v| v.unbind())
+        .unwrap_or(native)
+}

--- a/src/backends/pyo3/trait_bridge.rs
+++ b/src/backends/pyo3/trait_bridge.rs
@@ -84,12 +84,17 @@ pub fn gen_trait_bridge(
         // bridge extracts and converts via `From<Binding>` (falling back to the mapping/JSON path).
         let struct_return_types =
             crate::codegen::generators::trait_bridge::native_marshalled_struct_returns(trait_type, api);
+        // Rust-defaulted methods the bridge can forward to the host (host-defined
+        // implementations win; the Rust default runs otherwise).
+        let forwardable_defaulted =
+            crate::codegen::generators::trait_bridge::forwardable_defaulted_method_names(trait_type, api);
         let generator = Pyo3BridgeGenerator {
             core_import: core_import.to_string(),
             type_paths: type_paths.clone(),
             error_type: error_type.to_string(),
             struct_param_types,
             struct_return_types,
+            forwardable_defaulted,
         };
         let lifetime_type_names: HashSet<String> = api
             .types
@@ -160,6 +165,7 @@ mod tests {
             error_type: "SampleError".to_owned(),
             struct_param_types: HashSet::new(),
             struct_return_types: HashSet::new(),
+            forwardable_defaulted: HashSet::new(),
         };
 
         let make_method = |is_async: bool| MethodDef {
@@ -238,6 +244,7 @@ mod tests {
             error_type: "SampleError".to_owned(),
             struct_param_types: HashSet::new(),
             struct_return_types: HashSet::new(),
+            forwardable_defaulted: HashSet::new(),
         };
 
         // A trait method returning a struct `Doc` exercises the json.dumps -> from_str path.
@@ -308,6 +315,7 @@ mod tests {
             error_type: "SampleError".to_owned(),
             struct_param_types: HashSet::new(),
             struct_return_types: HashSet::from(["Doc".to_owned()]),
+            forwardable_defaulted: HashSet::new(),
         };
 
         let make_method = |is_async: bool| MethodDef {
@@ -384,6 +392,7 @@ mod tests {
             error_type: "SampleError".to_owned(),
             struct_param_types: HashSet::from(["Input".to_owned()]),
             struct_return_types: HashSet::new(),
+            forwardable_defaulted: HashSet::new(),
         };
 
         let make_method = |is_async: bool| MethodDef {

--- a/src/backends/pyo3/trait_bridge.rs
+++ b/src/backends/pyo3/trait_bridge.rs
@@ -30,7 +30,10 @@ pub fn gen_trait_bridge(
     error_type: &str,
     error_constructor: &str,
     api: &ApiSurface,
+    python_module: &str,
+    reexported_types: &[String],
 ) -> anyhow::Result<BridgeOutput> {
+    let _ = python_module;
     // Build type name → rust_path lookup for qualifying Named types in signatures
     let type_paths: HashMap<String, String> = api
         .types
@@ -88,6 +91,11 @@ pub fn gen_trait_bridge(
         // implementations win; the Rust default runs otherwise).
         let forwardable_defaulted =
             crate::codegen::generators::trait_bridge::forwardable_defaulted_method_names(trait_type, api);
+        // Config structs the package exports as options dataclasses: the bridge lifts
+        // the native object into the dataclass before invoking the host, so the type a
+        // host method receives is the type the package publicly exports.
+        let options_dataclass_types =
+            crate::backends::pyo3::gen_bindings::options_dataclass_type_names(api, reexported_types);
         let generator = Pyo3BridgeGenerator {
             core_import: core_import.to_string(),
             type_paths: type_paths.clone(),
@@ -95,6 +103,7 @@ pub fn gen_trait_bridge(
             struct_param_types,
             struct_return_types,
             forwardable_defaulted,
+            options_dataclass_types,
         };
         let lifetime_type_names: HashSet<String> = api
             .types
@@ -166,6 +175,7 @@ mod tests {
             struct_param_types: HashSet::new(),
             struct_return_types: HashSet::new(),
             forwardable_defaulted: HashSet::new(),
+            options_dataclass_types: HashSet::new(),
         };
 
         let make_method = |is_async: bool| MethodDef {
@@ -245,6 +255,7 @@ mod tests {
             struct_param_types: HashSet::new(),
             struct_return_types: HashSet::new(),
             forwardable_defaulted: HashSet::new(),
+            options_dataclass_types: HashSet::new(),
         };
 
         // A trait method returning a struct `Doc` exercises the json.dumps -> from_str path.
@@ -316,6 +327,7 @@ mod tests {
             struct_param_types: HashSet::new(),
             struct_return_types: HashSet::from(["Doc".to_owned()]),
             forwardable_defaulted: HashSet::new(),
+            options_dataclass_types: HashSet::new(),
         };
 
         let make_method = |is_async: bool| MethodDef {
@@ -393,6 +405,7 @@ mod tests {
             struct_param_types: HashSet::from(["Input".to_owned()]),
             struct_return_types: HashSet::new(),
             forwardable_defaulted: HashSet::new(),
+            options_dataclass_types: HashSet::new(),
         };
 
         let make_method = |is_async: bool| MethodDef {
@@ -438,6 +451,8 @@ mod tests {
             "SampleError",
             "SampleError::Message { message: {msg} }",
             &api,
+            "sample_core",
+            &[],
         )
         .expect("visitor bridge should generate");
 

--- a/src/backends/pyo3/trait_bridge.rs
+++ b/src/backends/pyo3/trait_bridge.rs
@@ -30,10 +30,8 @@ pub fn gen_trait_bridge(
     error_type: &str,
     error_constructor: &str,
     api: &ApiSurface,
-    python_module: &str,
     reexported_types: &[String],
 ) -> anyhow::Result<BridgeOutput> {
-    let _ = python_module;
     // Build type name → rust_path lookup for qualifying Named types in signatures
     let type_paths: HashMap<String, String> = api
         .types
@@ -451,7 +449,6 @@ mod tests {
             "SampleError",
             "SampleError::Message { message: {msg} }",
             &api,
-            "sample_core",
             &[],
         )
         .expect("visitor bridge should generate");

--- a/src/backends/pyo3/trait_bridge/generator.rs
+++ b/src/backends/pyo3/trait_bridge/generator.rs
@@ -31,6 +31,11 @@ pub struct Pyo3BridgeGenerator {
     /// object defines them (per the shared `forwardable_defaulted_method_names` rule).
     /// Methods absent here keep the trait's Rust default unconditionally.
     pub forwardable_defaulted: std::collections::HashSet<String>,
+    /// Struct types the package exports as options dataclasses. Callback params of
+    /// these types are lifted from the native pyclass into the public dataclass via
+    /// the generated `options._from_native_*` converter before invoking the host, so
+    /// the type the host receives is the type the package exports under that name.
+    pub options_dataclass_types: std::collections::HashSet<String>,
 }
 
 impl TraitBridgeGenerator for Pyo3BridgeGenerator {
@@ -402,12 +407,12 @@ impl Pyo3BridgeGenerator {
                 // (`{Binding}::from(core_value)`). PyO3 auto-converts the `#[pyclass]` to a Python
                 // object at the call boundary. No JSON round-trip.
                 (TypeRef::Named(n), true) if self.is_native_struct_param(n) => {
-                    format!("{}::from((*{}).clone())", n, p.name)
+                    self.options_lift_expr(n, format!("{}::from((*{}).clone())", n, p.name))
                 }
                 // By-value native struct: no deref needed; the owned value is moved into the sync
                 // closure, so clone it directly before wrapping in the binding type.
                 (TypeRef::Named(n), false) if self.is_native_struct_param(n) => {
-                    format!("{}::from({}.clone())", n, p.name)
+                    self.options_lift_expr(n, format!("{}::from({}.clone())", n, p.name))
                 }
                 // Other Named params (enums, opaque/handle, excluded/unknown) keep the prior
                 // JSON-string representation.
@@ -438,12 +443,12 @@ impl Pyo3BridgeGenerator {
                 // the same marshalling — passing the raw core value has no `IntoPyObject` (E0277).
                 // `{name}_owned` is owned by the closure and consumed once, so move it in.
                 (TypeRef::Named(n), _) if self.is_native_struct_param(n) => {
-                    format!("{}::from({}_owned)", n, p.name)
+                    self.options_lift_expr(n, format!("{}::from({}_owned)", n, p.name))
                 }
                 // By-value native struct: the param-cloning preamble stores the clone under
                 // the same name (`let {name} = {name}.clone()`); wrap it in the binding type.
                 (TypeRef::Named(n), false) if self.is_native_struct_param(n) => {
-                    format!("{}::from({}.clone())", n, p.name)
+                    self.options_lift_expr(n, format!("{}::from({}.clone())", n, p.name))
                 }
                 (TypeRef::Named(_), true) => format!("{}_json.as_str()", p.name),
                 _ => p.name.clone(),
@@ -453,6 +458,21 @@ impl Pyo3BridgeGenerator {
             format!("{},", args[0])
         } else {
             args.join(", ")
+        }
+    }
+
+    /// Wrap a native-pyclass expression in the options-dataclass lift when the type
+    /// is publicly exported as an options dataclass; otherwise pass the native object.
+    fn options_lift_expr(&self, type_name: &str, native_expr: String) -> String {
+        use heck::ToSnakeCase;
+        if self.options_dataclass_types.contains(type_name) {
+            format!(
+                "__alef_options_from_native(py, \"_from_native_{}\", {})",
+                type_name.to_snake_case(),
+                native_expr
+            )
+        } else {
+            native_expr
         }
     }
 

--- a/src/backends/pyo3/trait_bridge/generator.rs
+++ b/src/backends/pyo3/trait_bridge/generator.rs
@@ -27,11 +27,24 @@ pub struct Pyo3BridgeGenerator {
     /// return the bridge first tries to extract the host's native Python object and convert it via
     /// `From<Binding>` for the core type, falling back to the JSON/mapping path otherwise.
     pub struct_return_types: std::collections::HashSet<String>,
+    /// Rust-defaulted trait methods the bridge forwards to the host when the Python
+    /// object defines them (per the shared `forwardable_defaulted_method_names` rule).
+    /// Methods absent here keep the trait's Rust default unconditionally.
+    pub forwardable_defaulted: std::collections::HashSet<String>,
 }
 
 impl TraitBridgeGenerator for Pyo3BridgeGenerator {
     fn foreign_object_type(&self) -> &str {
         "Py<PyAny>"
+    }
+
+    fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        self.forwardable_defaulted.contains(&method.name).then(|| {
+            format!(
+                "Python::attach(|py| self.inner.bind(py).hasattr(\"{}\").unwrap_or(false))",
+                method.name
+            )
+        })
     }
 
     fn bridge_imports(&self) -> Vec<String> {

--- a/src/backends/pyo3/trait_bridge/generator.rs
+++ b/src/backends/pyo3/trait_bridge/generator.rs
@@ -38,6 +38,13 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
         "Py<PyAny>"
     }
 
+    fn gen_lifecycle_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        Some(format!(
+            "Python::attach(|py| self.inner.bind(py).hasattr(\"{}\").unwrap_or(false))",
+            method.name
+        ))
+    }
+
     fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
         self.forwardable_defaulted.contains(&method.name).then(|| {
             format!(

--- a/src/backends/rustler/gen_bindings/public_api_delegates.rs
+++ b/src/backends/rustler/gen_bindings/public_api_delegates.rs
@@ -35,6 +35,16 @@ fn callback_rows(
                 .params
                 .iter()
                 .map(|p| match (&p.ty, p.optional) {
+                    // Callback direction: the bridge encodes Named struct params as native
+                    // Erlang maps (see the GenServer bridge — "args arrives as a native
+                    // Erlang map"). The input-direction convention (configs as optional
+                    // JSON strings) does NOT apply here, so default_types structs are
+                    // `map()`, not `String.t() | nil`.
+                    (TypeRef::Named(name), false) if !opaque_types.contains(name) => "map()".to_string(),
+                    (TypeRef::Named(name), true) if !opaque_types.contains(name) => "map() | nil".to_string(),
+                    (TypeRef::Optional(inner), _) if matches!(inner.as_ref(), TypeRef::Named(n) if !opaque_types.contains(n)) => {
+                        "map() | nil".to_string()
+                    }
                     (TypeRef::Optional(_), _) | (_, true) => {
                         let base = elixir_typespec(&p.ty, opaque_types, default_types);
                         if base.ends_with("| nil") {
@@ -61,6 +71,25 @@ fn callback_rows(
             }
         })
         .collect()
+}
+
+/// `{name, arity}` pairs for `@optional_callbacks`: the Rust-defaulted trait
+/// methods (the bridge forwards them only when the module exports them) plus the
+/// `Plugin` lifecycle hooks.
+fn optional_callback_rows(methods: &[MethodDef]) -> Vec<minijinja::Value> {
+    let mut rows: Vec<minijinja::Value> = methods
+        .iter()
+        .filter(|m| m.has_default_impl)
+        .map(|m| {
+            minijinja::context! {
+                name => m.name.to_snake_case(),
+                arity => m.params.len(),
+            }
+        })
+        .collect();
+    rows.push(minijinja::context! { name => "initialize", arity => 0 });
+    rows.push(minijinja::context! { name => "shutdown", arity => 0 });
+    rows
 }
 
 /// Surface types the trait-bridge delegate emitter needs to type the host behaviour.
@@ -111,6 +140,7 @@ pub(in crate::backends::rustler::gen_bindings) fn append_trait_bridge_delegates(
                             trait_name => &bridge_cfg.trait_name,
                             register_fn => bridge_cfg.register_fn.as_deref().unwrap_or_default().to_snake_case(),
                             callbacks => callback_rows(&trait_def.methods, opaque_types, default_types),
+                            optional_callbacks => optional_callback_rows(&trait_def.methods),
                         },
                     ));
                     content.push('\n');

--- a/src/backends/rustler/templates/elixir_trait_behaviour.ex.jinja
+++ b/src/backends/rustler/templates/elixir_trait_behaviour.ex.jinja
@@ -3,13 +3,25 @@
     Typed host interface for the `{{ trait_name }}` plugin bridge.
 
     A plugin handler module implements this behaviour and is registered with
-    `{{ register_fn }}/2`. Each callback receives the decoded arguments for a
+    `{{ register_fn }}`. Each callback receives the decoded arguments for a
     trait method and returns the method's result. The dispatching GenServer
     passes the decoded `args` map to the callback for the corresponding method.
+
+    The optional callbacks are Rust-defaulted trait methods (plus the
+    `initialize`/`shutdown` lifecycle hooks): the bridge calls them when the
+    module exports them, otherwise the trait's Rust default behavior applies.
     """
 {% for cb in callbacks %}
 
     @doc "Handle the `{{ cb.method }}` trait call."
     @callback {{ cb.name }}({{ cb.params_spec }}) :: {{ cb.return_spec }}
 {% endfor %}
+
+    @doc "Optional lifecycle hook, called at plugin registration."
+    @callback initialize() :: any()
+
+    @doc "Optional lifecycle hook, called at plugin unregistration."
+    @callback shutdown() :: any()
+
+    @optional_callbacks [{% for cb in optional_callbacks %}{{ cb.name }}: {{ cb.arity }}{% if not loop.last %}, {% endif %}{% endfor %}]
   end

--- a/src/backends/rustler/templates/elixir_trait_register_delegate.ex.jinja
+++ b/src/backends/rustler/templates/elixir_trait_register_delegate.ex.jinja
@@ -3,8 +3,13 @@
 
   The GenServer should dispatch `{:trait_call, ...}` messages to a module that
   implements the `{{ behaviour_module }}` behaviour.
+
+  The optional `implemented_methods` lists the function names the implementation
+  module exports; Rust-defaulted trait methods outside this list keep their Rust
+  default behavior. The scaffolded bridge module's `register/1` fills it in
+  automatically from the implementation module's exports.
   """
-  @spec {{ func_name }}(pid(), String.t()) :: :ok | :error
-  def {{ func_name }}(genserver_pid, plugin_name) do
-    {{ native_mod }}.{{ func_name }}(genserver_pid, plugin_name)
+  @spec {{ func_name }}(pid(), String.t(), [String.t()]) :: :ok | :error
+  def {{ func_name }}(genserver_pid, plugin_name, implemented_methods \\ []) do
+    {{ native_mod }}.{{ func_name }}(genserver_pid, plugin_name, implemented_methods)
   end

--- a/src/backends/rustler/templates/trait_constructor.rs.jinja
+++ b/src/backends/rustler/templates/trait_constructor.rs.jinja
@@ -3,7 +3,13 @@ impl {{ wrapper_name }} {
     ///
     /// The PID is stored directly (it is Copy + Send + Sync).
     /// Messages are dispatched via the trait methods using channels for sync/async dispatch.
-    pub fn new(pid: rustler::LocalPid, name: String) -> Self {
-        Self { inner: pid, cached_name: name }
+    /// `implemented_methods` lists the functions the implementation module exports;
+    /// Rust-defaulted trait methods outside this set fall back to their default bodies.
+    pub fn new(pid: rustler::LocalPid, name: String, implemented_methods: Vec<String>) -> Self {
+        Self {
+            inner: pid,
+            cached_name: name,
+            implemented_methods: implemented_methods.into_iter().collect(),
+        }
     }
 }

--- a/src/backends/rustler/templates/trait_registration_fn.rs.jinja
+++ b/src/backends/rustler/templates/trait_registration_fn.rs.jinja
@@ -1,6 +1,6 @@
 #[rustler::nif(schedule = "DirtyCpu")]
-pub fn {{ register_fn }}(env: rustler::Env<'_>, genserver_pid: rustler::LocalPid, plugin_name: String) -> rustler::Atom {
-    let wrapper = {{ wrapper_name }}::new(genserver_pid, plugin_name);
+pub fn {{ register_fn }}(env: rustler::Env<'_>, genserver_pid: rustler::LocalPid, plugin_name: String, implemented_methods: Vec<String>) -> rustler::Atom {
+    let wrapper = {{ wrapper_name }}::new(genserver_pid, plugin_name, implemented_methods);
     let arc: std::sync::Arc<dyn {{ trait_path }}> = std::sync::Arc::new(wrapper);
 
     match {{ registry_getter }}()

--- a/src/backends/rustler/trait_bridge/generator.rs
+++ b/src/backends/rustler/trait_bridge/generator.rs
@@ -22,6 +22,12 @@ pub struct RustlerBridgeGenerator {
     /// natural native terms (strings, numbers, booleans, lists); enums/opaque/unknown `Named` params
     /// fall back to a debug string term.
     pub struct_param_types: std::collections::HashSet<String>,
+    /// Rust-defaulted trait methods the bridge forwards to the host when the
+    /// implementation module exports them. The exported-function names are
+    /// supplied by the Elixir side at registration (the GenServer bridge knows
+    /// its impl_module) and stored on the wrapper as `implemented_methods`.
+    /// Methods absent here keep the trait's Rust default unconditionally.
+    pub forwardable_defaulted: std::collections::HashSet<String>,
 }
 
 /// Generate all trait bridge code for a given trait type and bridge config.
@@ -89,11 +95,16 @@ pub fn gen_trait_bridge(
         // terms.
         let struct_param_types =
             crate::codegen::generators::trait_bridge::native_marshalled_struct_params(trait_type, api);
+        // Rust-defaulted methods the bridge can forward to the host (host-exported
+        // implementations win; the Rust default runs otherwise).
+        let forwardable_defaulted =
+            crate::codegen::generators::trait_bridge::forwardable_defaulted_method_names(trait_type, api);
         let generator = super::generator::RustlerBridgeGenerator {
             core_import: core_import.to_string(),
             type_paths: type_paths.clone(),
             error_type: error_type.to_string(),
             struct_param_types,
+            forwardable_defaulted,
         };
         let lifetime_type_names: std::collections::HashSet<String> = api
             .types

--- a/src/backends/rustler/trait_bridge/methods.rs
+++ b/src/backends/rustler/trait_bridge/methods.rs
@@ -8,6 +8,23 @@ impl TraitBridgeGenerator for RustlerBridgeGenerator {
         "rustler::LocalPid"
     }
 
+    fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        // The exported-function set is supplied by the Elixir side at registration
+        // (the GenServer bridge knows its impl_module) and cached on the wrapper.
+        self.forwardable_defaulted
+            .contains(&method.name)
+            .then(|| format!("self.implemented_methods.contains(\"{}\")", method.name))
+    }
+
+    fn extra_bridge_fields(&self, _spec: &TraitBridgeSpec) -> Vec<(String, String)> {
+        // Unconditional so every plugin bridge has the same constructor and
+        // registration arity, whether or not the trait has defaulted methods.
+        vec![(
+            "implemented_methods".to_string(),
+            "std::collections::HashSet<String>".to_string(),
+        )]
+    }
+
     fn bridge_imports(&self) -> Vec<String> {
         // async_trait is needed because the trait impls may have async methods.
         // We import the prelude to ensure the async_trait attribute is available.

--- a/src/backends/rustler/trait_bridge/methods.rs
+++ b/src/backends/rustler/trait_bridge/methods.rs
@@ -8,6 +8,10 @@ impl TraitBridgeGenerator for RustlerBridgeGenerator {
         "rustler::LocalPid"
     }
 
+    fn gen_lifecycle_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        Some(format!("self.implemented_methods.contains(\"{}\")", method.name))
+    }
+
     fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
         // The exported-function set is supplied by the Elixir side at registration
         // (the GenServer bridge knows its impl_module) and cached on the wrapper.

--- a/src/backends/wasm/trait_bridge.rs
+++ b/src/backends/wasm/trait_bridge.rs
@@ -61,9 +61,22 @@ pub struct WasmBridgeGenerator {
     pub error_type: String,
     /// Set of type names that are enums (bare-string serialized).
     pub enum_names: std::collections::HashSet<String>,
+    /// Rust-defaulted trait methods the bridge forwards to the host when the JS
+    /// object defines them (per the shared `forwardable_defaulted_method_names`
+    /// rule). Methods absent here keep the trait's Rust default unconditionally.
+    pub forwardable_defaulted: std::collections::HashSet<String>,
 }
 
 impl TraitBridgeGenerator for WasmBridgeGenerator {
+    fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        self.forwardable_defaulted.contains(&method.name).then(|| {
+            format!(
+                "js_sys::Reflect::get(&self.inner, &wasm_bindgen::JsValue::from_str(\"{}\")).map(|v| v.is_function()).unwrap_or(false)",
+                method.name
+            )
+        })
+    }
+
     fn foreign_object_type(&self) -> &str {
         "wasm_bindgen::JsValue"
     }
@@ -389,11 +402,16 @@ pub fn gen_trait_bridge(
     } else {
         // Use the IR-driven TraitBridgeGenerator infrastructure for plugin pattern
         let enum_names: std::collections::HashSet<String> = api.enums.iter().map(|e| e.name.clone()).collect();
+        // Rust-defaulted methods the bridge can forward to the host (host-defined
+        // implementations win; the Rust default runs otherwise).
+        let forwardable_defaulted =
+            crate::codegen::generators::trait_bridge::forwardable_defaulted_method_names(trait_type, api);
         let generator = WasmBridgeGenerator {
             core_import: core_import.to_string(),
             type_paths: type_paths.clone(),
             error_type: error_type.to_string(),
             enum_names,
+            forwardable_defaulted,
         };
         let lifetime_type_names: std::collections::HashSet<String> = api
             .types
@@ -985,5 +1003,52 @@ mod tests {
         assert!(code.contains("__alef_wasm_bridge_xmlwalker::WasmXmlWalkerBridge::new(visitor)"));
         assert!(!code.contains("__alef_wasm_bridge_htmlvisitor"));
         assert!(!code.contains("WasmHtmlVisitorBridge"));
+    }
+    #[test]
+    fn presence_check_emitted_only_for_forwardable_defaulted_methods() {
+        let mut generator = WasmBridgeGenerator {
+            core_import: "sample_core".to_string(),
+            type_paths: std::collections::HashMap::new(),
+            error_type: "SampleError".to_string(),
+            enum_names: std::collections::HashSet::new(),
+            forwardable_defaulted: std::collections::HashSet::new(),
+        };
+        let trait_def = crate::core::ir::TypeDef {
+            name: "OcrBackend".to_string(),
+            rust_path: "sample_core::OcrBackend".to_string(),
+            is_trait: true,
+            is_opaque: true,
+            ..Default::default()
+        };
+        let bridge = TraitBridgeConfig {
+            trait_name: "OcrBackend".to_string(),
+            ..TraitBridgeConfig::default()
+        };
+        let spec = crate::codegen::generators::trait_bridge::TraitBridgeSpec {
+            trait_def: &trait_def,
+            bridge_config: &bridge,
+            core_import: "sample_core",
+            wrapper_prefix: "Wasm",
+            type_paths: std::collections::HashMap::new(),
+            lifetime_type_names: std::collections::HashSet::new(),
+            error_type: "SampleError".to_string(),
+            error_constructor: "SampleError::Message { message: {msg} }".to_string(),
+        };
+        let method = crate::core::ir::MethodDef {
+            name: "supports_table_detection".to_string(),
+            has_default_impl: true,
+            receiver: Some(crate::core::ir::ReceiverKind::Ref),
+            ..Default::default()
+        };
+        assert!(generator.gen_method_presence_check(&method, &spec).is_none());
+        generator
+            .forwardable_defaulted
+            .insert("supports_table_detection".to_string());
+        let check = generator.gen_method_presence_check(&method, &spec).unwrap();
+        assert!(
+            check.contains("js_sys::Reflect::get"),
+            "wasm presence check must use Reflect: {check}"
+        );
+        assert!(check.contains("supports_table_detection"));
     }
 }

--- a/src/backends/wasm/trait_bridge.rs
+++ b/src/backends/wasm/trait_bridge.rs
@@ -68,6 +68,13 @@ pub struct WasmBridgeGenerator {
 }
 
 impl TraitBridgeGenerator for WasmBridgeGenerator {
+    fn gen_lifecycle_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        Some(format!(
+            "js_sys::Reflect::get(&self.inner, &wasm_bindgen::JsValue::from_str(\"{}\")).map(|v| v.is_function()).unwrap_or(false)",
+            method.name
+        ))
+    }
+
     fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
         self.forwardable_defaulted.contains(&method.name).then(|| {
             format!(

--- a/src/codegen/generators/trait_bridge.rs
+++ b/src/codegen/generators/trait_bridge.rs
@@ -22,8 +22,9 @@ pub use formatting::{
 pub use generator::{BridgeOutput, TraitBridgeGenerator, gen_bridge_all};
 pub use lookup::{
     BridgeFieldMatch, bridge_handle_path, bridge_wrapper_name, find_bridge_field, find_bridge_param, find_trait_def,
-    is_bridge_handle_type_ref, is_native_marshalled_struct, is_trait_bridge_managed_fn,
-    native_marshalled_struct_params, native_marshalled_struct_returns,
+    forwardable_defaulted_method_names, is_bridge_handle_type_ref, is_native_marshalled_struct,
+    is_trait_bridge_managed_fn, method_signature_references_trait, native_marshalled_struct_params,
+    native_marshalled_struct_returns, type_references_trait,
 };
 pub use registration::{
     gen_bridge_clear_fn, gen_bridge_registration_fn, gen_bridge_unregistration_fn, host_function_path,

--- a/src/codegen/generators/trait_bridge.rs
+++ b/src/codegen/generators/trait_bridge.rs
@@ -5,6 +5,7 @@
 //! to provide language-specific dispatch logic; the shared functions in this module
 //! handle the structural boilerplate.
 
+mod delegates;
 mod formatting;
 mod generator;
 mod lookup;
@@ -13,9 +14,10 @@ mod spec;
 mod trait_impl;
 mod wrapper;
 
+pub use delegates::{default_delegate_name, forwarded_defaulted_methods, gen_bridge_default_delegates};
 pub use formatting::{
-    bridge_param_type, format_param_type, format_param_type_with_lifetimes, format_return_type, format_type_ref, prim,
-    to_camel_case, visitor_param_type,
+    TraitMethodSig, bridge_param_type, format_param_type, format_param_type_with_lifetimes, format_return_type,
+    format_type_ref, prim, to_camel_case, trait_method_signature, visitor_param_type,
 };
 pub use generator::{BridgeOutput, TraitBridgeGenerator, gen_bridge_all};
 pub use lookup::{

--- a/src/codegen/generators/trait_bridge/delegates.rs
+++ b/src/codegen/generators/trait_bridge/delegates.rs
@@ -1,0 +1,120 @@
+use heck::ToPascalCase;
+
+use super::{TraitBridgeGenerator, TraitBridgeSpec, trait_method_signature};
+use crate::core::ir::{MethodDef, ReceiverKind};
+
+/// Name of the per-method default delegate type, e.g.
+/// `PyOcrBackendBridgeDefaultProcessDocument`.
+pub fn default_delegate_name(spec: &TraitBridgeSpec, method: &MethodDef) -> String {
+    format!("{}Default{}", spec.wrapper_name(), method.name.to_pascal_case())
+}
+
+/// The Rust-defaulted own methods this bridge forwards to the host: the generator
+/// opted the method in via [`TraitBridgeGenerator::gen_method_presence_check`] and
+/// the method's shape supports guard-and-delegate emission (`&self` receiver, owned
+/// return). Methods excluded here keep the previous behavior — omitted from the
+/// bridge impl, so the trait's default body always runs.
+pub fn forwarded_defaulted_methods<'a>(
+    spec: &TraitBridgeSpec<'a>,
+    generator: &dyn TraitBridgeGenerator,
+) -> Vec<&'a MethodDef> {
+    spec.trait_def
+        .methods
+        .iter()
+        .filter(|m| {
+            m.trait_source.is_none()
+                && m.has_default_impl
+                && !m.returns_ref
+                && matches!(m.receiver, Some(ReceiverKind::Ref))
+                && generator.gen_method_presence_check(m, spec).is_some()
+        })
+        .collect()
+}
+
+/// Generate the per-method default delegates for every forwarded defaulted method.
+///
+/// For a defaulted method `x`, `WrapperDefaultX` implements the trait by forwarding
+/// every own method EXCEPT `x` back through the bridge — so when the bridge falls
+/// back to `WrapperDefaultX(self).x(...)`, the trait's genuine Rust default body for
+/// `x` runs, and any `self.*` call inside that body still reaches host overrides.
+/// The `Plugin` super-trait (when configured) is forwarded for the same reason.
+///
+/// Returns an empty string when the generator forwards no defaulted methods.
+pub fn gen_bridge_default_delegates(spec: &TraitBridgeSpec, generator: &dyn TraitBridgeGenerator) -> String {
+    let forwarded = forwarded_defaulted_methods(spec, generator);
+    if forwarded.is_empty() {
+        return String::new();
+    }
+
+    let wrapper = spec.wrapper_name();
+    let trait_path = spec.trait_path();
+    let super_trait_path = spec.bridge_config.super_trait.as_deref().map(|name| {
+        if name.contains("::") {
+            name.to_string()
+        } else {
+            format!("{}::{}", spec.core_import, name)
+        }
+    });
+    let error_path = spec.error_path();
+
+    let own_methods: Vec<&MethodDef> = spec
+        .trait_def
+        .methods
+        .iter()
+        .filter(|m| m.trait_source.is_none())
+        .collect();
+
+    let mut out = String::with_capacity(2048);
+    for (i, defaulted) in forwarded.iter().enumerate() {
+        if i > 0 {
+            out.push_str("\n\n");
+        }
+
+        // Forward every own method except the delegated one. Methods the bridge does
+        // not emit at all (non-forwarded defaulted methods) are also skipped — the
+        // delegate inherits their default bodies the same way the bridge does.
+        let bridge_emitted: Vec<&&MethodDef> = own_methods
+            .iter()
+            .filter(|m| m.name != defaulted.name && (!m.has_default_impl || forwarded.iter().any(|f| f.name == m.name)))
+            .collect();
+
+        let methods: Vec<minijinja::Value> = bridge_emitted
+            .iter()
+            .map(|m| {
+                let sig = trait_method_signature(m, spec);
+                let args = if sig.arg_names.is_empty() {
+                    "self.0".to_string()
+                } else {
+                    format!("self.0, {}", sig.arg_names)
+                };
+                let await_suffix = if m.is_async { ".await" } else { "" };
+                minijinja::context! {
+                    async_kw => sig.async_kw,
+                    name => &m.name,
+                    all_params => sig.all_params,
+                    ret => sig.ret,
+                    forward_call => format!("{trait_path}::{}({args}){await_suffix}", m.name),
+                }
+            })
+            .collect();
+
+        let has_async_methods = bridge_emitted.iter().any(|m| m.is_async);
+
+        out.push_str(&crate::codegen::template_env::render(
+            "generators/trait_bridge/default_delegate.jinja",
+            minijinja::context! {
+                delegate_name => default_delegate_name(spec, defaulted),
+                method_name => &defaulted.name,
+                wrapper_name => &wrapper,
+                trait_path => &trait_path,
+                super_trait_path => super_trait_path.as_deref(),
+                error_path => &error_path,
+                has_async_methods => has_async_methods,
+                async_trait_is_send => generator.async_trait_is_send(),
+                methods => methods,
+            },
+        ));
+    }
+
+    out
+}

--- a/src/codegen/generators/trait_bridge/formatting.rs
+++ b/src/codegen/generators/trait_bridge/formatting.rs
@@ -288,3 +288,64 @@ pub fn to_camel_case(s: &str) -> String {
     }
     result
 }
+
+/// Signature parts for one bridge trait-impl method, shared between the wrapper's
+/// trait impl and the default-delegate impls so both emit identical signatures.
+pub struct TraitMethodSig {
+    /// `"async "` or `""`.
+    pub async_kw: &'static str,
+    /// Full parameter list including the receiver, e.g. `"&self, path: &std::path::Path"`.
+    pub all_params: String,
+    /// Formatted return type (crate error type substituted).
+    pub ret: String,
+    /// Comma-joined argument names for forwarding calls, e.g. `"path, config"`.
+    pub arg_names: String,
+}
+
+/// Build the Rust signature parts for a trait method as the bridge emits it.
+pub fn trait_method_signature(method: &crate::core::ir::MethodDef, spec: &super::TraitBridgeSpec) -> TraitMethodSig {
+    let async_kw = if method.is_async { "async " } else { "" };
+    let receiver = match &method.receiver {
+        Some(crate::core::ir::ReceiverKind::Ref) => "&self",
+        Some(crate::core::ir::ReceiverKind::RefMut) => "&mut self",
+        Some(crate::core::ir::ReceiverKind::Owned) => "self",
+        None => "",
+    };
+
+    let params: Vec<String> = method
+        .params
+        .iter()
+        .map(|p| {
+            format!(
+                "{}: {}",
+                p.name,
+                format_param_type_with_lifetimes(p, &spec.type_paths, &spec.lifetime_type_names)
+            )
+        })
+        .collect();
+
+    let all_params = if receiver.is_empty() {
+        params.join(", ")
+    } else if params.is_empty() {
+        receiver.to_string()
+    } else {
+        format!("{}, {}", receiver, params.join(", "))
+    };
+
+    let error_override = method.error_type.as_ref().map(|_| spec.error_path());
+    let ret = format_return_type(
+        &method.return_type,
+        error_override.as_deref(),
+        &spec.type_paths,
+        method.returns_ref,
+    );
+
+    let arg_names: Vec<&str> = method.params.iter().map(|p| p.name.as_str()).collect();
+
+    TraitMethodSig {
+        async_kw,
+        all_params,
+        ret,
+        arg_names: arg_names.join(", "),
+    }
+}

--- a/src/codegen/generators/trait_bridge/generator.rs
+++ b/src/codegen/generators/trait_bridge/generator.rs
@@ -79,6 +79,17 @@ pub trait TraitBridgeGenerator {
         None
     }
 
+    /// Presence-check expression for a `Plugin` lifecycle method (`initialize`,
+    /// `shutdown`) synthesized by the super-trait impl.
+    ///
+    /// Return `Some(expr)` to make the bridge treat a host object that doesn't
+    /// define the method as a no-op (`Ok(())`) instead of failing at
+    /// registration/unregistration. The default `None` keeps the prior behavior
+    /// (the generated body decides, typically erroring on a missing method).
+    fn gen_lifecycle_presence_check(&self, _method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        None
+    }
+
     /// Extra fields on the wrapper struct, as `(name, rust_type)` pairs.
     ///
     /// Backends whose foreign objects cannot be probed safely at call time

--- a/src/codegen/generators/trait_bridge/generator.rs
+++ b/src/codegen/generators/trait_bridge/generator.rs
@@ -78,6 +78,16 @@ pub trait TraitBridgeGenerator {
     fn gen_method_presence_check(&self, _method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
         None
     }
+
+    /// Extra fields on the wrapper struct, as `(name, rust_type)` pairs.
+    ///
+    /// Backends whose foreign objects cannot be probed safely at call time
+    /// (thread-affine values like Ruby `Value`s or JS objects behind an env)
+    /// cache method-presence flags here at construction; their
+    /// `gen_constructor` must initialize every declared field.
+    fn extra_bridge_fields(&self, _spec: &TraitBridgeSpec) -> Vec<(String, String)> {
+        Vec::new()
+    }
 }
 
 pub struct BridgeOutput {

--- a/src/codegen/generators/trait_bridge/generator.rs
+++ b/src/codegen/generators/trait_bridge/generator.rs
@@ -63,6 +63,21 @@ pub trait TraitBridgeGenerator {
     fn async_trait_is_send(&self) -> bool {
         true
     }
+
+    /// Presence-check expression for a Rust-defaulted trait method.
+    ///
+    /// Return `Some(expr)` — a Rust expression, valid inside the bridge's trait-impl
+    /// methods, evaluating to `true` when the wrapped foreign object provides
+    /// `method` — to opt the method in to defaulted-method forwarding: the bridge
+    /// then calls the host implementation when the host defines the method and
+    /// falls back to the trait's genuine Rust default body (via a per-method
+    /// delegate) otherwise.
+    ///
+    /// The default `None` keeps the prior behavior: the method is omitted from the
+    /// bridge impl and the Rust default always runs, ignoring host implementations.
+    fn gen_method_presence_check(&self, _method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        None
+    }
 }
 
 pub struct BridgeOutput {
@@ -101,6 +116,13 @@ pub fn gen_bridge_all(spec: &TraitBridgeSpec, generator: &dyn TraitBridgeGenerat
 
     // Trait impl
     out.push_str(&gen_bridge_trait_impl(spec, generator));
+
+    // Default delegates — only when the generator forwards defaulted methods
+    let delegates = super::gen_bridge_default_delegates(spec, generator);
+    if !delegates.is_empty() {
+        out.push_str("\n\n");
+        out.push_str(&delegates);
+    }
 
     // Registration function — only when register_fn is configured
     if let Some(reg_fn_code) = gen_bridge_registration_fn(spec, generator) {

--- a/src/codegen/generators/trait_bridge/lookup.rs
+++ b/src/codegen/generators/trait_bridge/lookup.rs
@@ -253,3 +253,36 @@ fn field_type_matches_alias(field_ty: &TypeRef, alias: &str) -> bool {
         _ => false,
     }
 }
+
+/// True when a `TypeRef` references a trait type (directly or through
+/// `Option`/`Vec`/`Map` wrappers). Trait-typed values cannot cross a foreign
+/// bridge — the host cannot construct or return a Rust trait object — so
+/// methods whose signature references a trait are excluded from
+/// defaulted-method forwarding and keep the Rust default unconditionally.
+pub fn type_references_trait(ty: &TypeRef, api: &ApiSurface) -> bool {
+    match ty {
+        TypeRef::Named(name) => {
+            api.types.iter().any(|t| t.is_trait && &t.name == name) || api.excluded_trait_names.contains(name)
+        }
+        TypeRef::Optional(inner) | TypeRef::Vec(inner) => type_references_trait(inner, api),
+        TypeRef::Map(k, v) => type_references_trait(k, api) || type_references_trait(v, api),
+        _ => false,
+    }
+}
+
+/// True when any param or the return type of `method` references a trait type.
+pub fn method_signature_references_trait(method: &crate::core::ir::MethodDef, api: &ApiSurface) -> bool {
+    type_references_trait(&method.return_type, api) || method.params.iter().any(|p| type_references_trait(&p.ty, api))
+}
+
+/// The names of the Rust-defaulted own methods of `trait_type` whose signatures a
+/// foreign bridge can marshal — the standard input to a backend's
+/// defaulted-method forwarding opt-in (`gen_method_presence_check`).
+pub fn forwardable_defaulted_method_names(trait_type: &TypeDef, api: &ApiSurface) -> std::collections::HashSet<String> {
+    trait_type
+        .methods
+        .iter()
+        .filter(|m| m.trait_source.is_none() && m.has_default_impl && !method_signature_references_trait(m, api))
+        .map(|m| m.name.clone())
+        .collect()
+}

--- a/src/codegen/generators/trait_bridge/tests/generation.rs
+++ b/src/codegen/generators/trait_bridge/tests/generation.rs
@@ -450,3 +450,175 @@ fn test_gen_bridge_all_ordering_struct_before_trait_impl() {
         .unwrap();
     assert!(struct_pos < impl_pos, "struct should appear before trait impl");
 }
+
+// ---------------------------------------------------------------------------
+// Defaulted-method forwarding (gen_method_presence_check hook)
+// ---------------------------------------------------------------------------
+
+/// Mock generator that opts in to defaulted-method forwarding.
+struct MockForwardingGenerator;
+
+impl TraitBridgeGenerator for MockForwardingGenerator {
+    fn foreign_object_type(&self) -> &str {
+        MockBridgeGenerator.foreign_object_type()
+    }
+
+    fn bridge_imports(&self) -> Vec<String> {
+        MockBridgeGenerator.bridge_imports()
+    }
+
+    fn gen_sync_method_body(&self, method: &MethodDef, spec: &TraitBridgeSpec) -> String {
+        MockBridgeGenerator.gen_sync_method_body(method, spec)
+    }
+
+    fn gen_async_method_body(&self, method: &MethodDef, spec: &TraitBridgeSpec) -> String {
+        MockBridgeGenerator.gen_async_method_body(method, spec)
+    }
+
+    fn gen_constructor(&self, spec: &TraitBridgeSpec) -> String {
+        MockBridgeGenerator.gen_constructor(spec)
+    }
+
+    fn gen_registration_fn(&self, spec: &TraitBridgeSpec) -> String {
+        MockBridgeGenerator.gen_registration_fn(spec)
+    }
+
+    fn gen_method_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        Some(format!("self.host_has(\"{}\")", method.name))
+    }
+}
+
+fn ocr_like_trait() -> TypeDef {
+    make_type_def(
+        "OcrBackend",
+        "mylib::OcrBackend",
+        vec![
+            make_method(
+                "process_image",
+                vec![make_param("image_bytes", TypeRef::Bytes, true)],
+                TypeRef::Named("ExtractionResult".to_string()),
+                true,
+                false,
+                None,
+                Some("MyError"),
+            ),
+            make_method(
+                "supports_language",
+                vec![],
+                TypeRef::Primitive(PrimitiveType::Bool),
+                false,
+                false,
+                None,
+                None,
+            ),
+            make_method(
+                "supports_table_detection",
+                vec![],
+                TypeRef::Primitive(PrimitiveType::Bool),
+                false,
+                true,
+                None,
+                None,
+            ),
+            make_method(
+                "process_document",
+                vec![make_param("path", TypeRef::Path, true)],
+                TypeRef::Named("ExtractionResult".to_string()),
+                true,
+                true,
+                None,
+                Some("MyError"),
+            ),
+        ],
+    )
+}
+
+#[test]
+fn trait_impl_without_hook_still_skips_defaulted_methods() {
+    let trait_def = ocr_like_trait();
+    let config = make_trait_bridge_config(Some("Plugin"), Some("register_ocr_backend"));
+    let spec = make_spec(&trait_def, &config, "Py", HashMap::new());
+    let result = gen_bridge_trait_impl(&spec, &MockBridgeGenerator);
+    assert!(
+        !result.contains("fn supports_table_detection"),
+        "defaulted method must stay omitted without the presence hook:\n{result}"
+    );
+}
+
+#[test]
+fn trait_impl_with_hook_forwards_defaulted_methods_with_guard() {
+    let trait_def = ocr_like_trait();
+    let config = make_trait_bridge_config(Some("Plugin"), Some("register_ocr_backend"));
+    let spec = make_spec(&trait_def, &config, "Py", HashMap::new());
+    let result = gen_bridge_trait_impl(&spec, &MockForwardingGenerator);
+    assert!(
+        result.contains("fn supports_table_detection"),
+        "defaulted method must be emitted when the generator opts in:\n{result}"
+    );
+    assert!(
+        result.contains("self.host_has(\"supports_table_detection\")"),
+        "presence guard must use the generator's check expression:\n{result}"
+    );
+    assert!(
+        result.contains("PyOcrBackendBridgeDefaultSupportsTableDetection(self).supports_table_detection()"),
+        "fallback must delegate to the trait's default body via the per-method delegate:\n{result}"
+    );
+    assert!(
+        result.contains("PyOcrBackendBridgeDefaultProcessDocument(self).process_document(path).await"),
+        "async fallback must await the delegate call:\n{result}"
+    );
+}
+
+#[test]
+fn default_delegates_route_other_methods_back_through_bridge() {
+    let trait_def = ocr_like_trait();
+    let config = make_trait_bridge_config(Some("Plugin"), Some("register_ocr_backend"));
+    let spec = make_spec(&trait_def, &config, "Py", HashMap::new());
+    let output = gen_bridge_all(&spec, &MockForwardingGenerator);
+    let code = &output.code;
+    assert!(
+        code.contains("struct PyOcrBackendBridgeDefaultSupportsTableDetection<'a>(&'a PyOcrBackendBridge);"),
+        "delegate struct missing:\n{code}"
+    );
+    // The delegate for supports_table_detection must forward every OTHER own method to the
+    // bridge (so the default body's `self.*` calls see host overrides) and must NOT override
+    // supports_table_detection itself (so the genuine Rust default body runs).
+    let delegate_impl_start = code
+        .find("impl mylib::OcrBackend for PyOcrBackendBridgeDefaultSupportsTableDetection<'_>")
+        .expect("delegate trait impl missing");
+    let delegate_impl = &code[delegate_impl_start..];
+    let delegate_impl_end = delegate_impl
+        .find("\n}\n")
+        .map(|i| &delegate_impl[..i])
+        .unwrap_or(delegate_impl);
+    assert!(
+        delegate_impl_end.contains("fn process_image"),
+        "delegate must forward required methods:\n{delegate_impl_end}"
+    );
+    assert!(
+        delegate_impl_end.contains("fn process_document"),
+        "delegate must forward the other defaulted method back through the bridge:\n{delegate_impl_end}"
+    );
+    assert!(
+        !delegate_impl_end.contains("fn supports_table_detection"),
+        "delegate must not override its own method:\n{delegate_impl_end}"
+    );
+    // Plugin super-trait must be forwarded so default bodies can call lifecycle/name methods.
+    assert!(
+        code.contains("impl mylib::Plugin for PyOcrBackendBridgeDefaultSupportsTableDetection<'_>"),
+        "delegate must forward the Plugin super-trait:\n{code}"
+    );
+}
+
+#[test]
+fn no_delegates_emitted_without_hook() {
+    let trait_def = ocr_like_trait();
+    let config = make_trait_bridge_config(Some("Plugin"), Some("register_ocr_backend"));
+    let spec = make_spec(&trait_def, &config, "Py", HashMap::new());
+    let output = gen_bridge_all(&spec, &MockBridgeGenerator);
+    assert!(
+        !output.code.contains("DefaultSupportsTableDetection"),
+        "delegates must not be emitted when the generator does not opt in:\n{}",
+        output.code
+    );
+}

--- a/src/codegen/generators/trait_bridge/tests/generation.rs
+++ b/src/codegen/generators/trait_bridge/tests/generation.rs
@@ -622,3 +622,64 @@ fn no_delegates_emitted_without_hook() {
         output.code
     );
 }
+
+/// Mock generator that also opts lifecycle methods in to no-op tolerance.
+struct MockLifecycleGenerator;
+
+impl TraitBridgeGenerator for MockLifecycleGenerator {
+    fn foreign_object_type(&self) -> &str {
+        MockBridgeGenerator.foreign_object_type()
+    }
+
+    fn bridge_imports(&self) -> Vec<String> {
+        MockBridgeGenerator.bridge_imports()
+    }
+
+    fn gen_sync_method_body(&self, method: &MethodDef, spec: &TraitBridgeSpec) -> String {
+        MockBridgeGenerator.gen_sync_method_body(method, spec)
+    }
+
+    fn gen_async_method_body(&self, method: &MethodDef, spec: &TraitBridgeSpec) -> String {
+        MockBridgeGenerator.gen_async_method_body(method, spec)
+    }
+
+    fn gen_constructor(&self, spec: &TraitBridgeSpec) -> String {
+        MockBridgeGenerator.gen_constructor(spec)
+    }
+
+    fn gen_registration_fn(&self, spec: &TraitBridgeSpec) -> String {
+        MockBridgeGenerator.gen_registration_fn(spec)
+    }
+
+    fn gen_lifecycle_presence_check(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> Option<String> {
+        Some(format!("self.host_has(\"{}\")", method.name))
+    }
+}
+
+#[test]
+fn lifecycle_methods_noop_when_host_lacks_them() {
+    let trait_def = ocr_like_trait();
+    let config = make_trait_bridge_config(Some("Plugin"), Some("register_ocr_backend"));
+    let spec = make_spec(&trait_def, &config, "Py", HashMap::new());
+    let result = gen_bridge_plugin_impl(&spec, &MockLifecycleGenerator).expect("plugin impl");
+    assert!(
+        result.contains("if !(self.host_has(\"initialize\")) {"),
+        "initialize must be guarded by the lifecycle presence check:\n{result}"
+    );
+    assert!(
+        result.contains("if !(self.host_has(\"shutdown\")) {"),
+        "shutdown must be guarded by the lifecycle presence check:\n{result}"
+    );
+}
+
+#[test]
+fn lifecycle_methods_unguarded_without_hook() {
+    let trait_def = ocr_like_trait();
+    let config = make_trait_bridge_config(Some("Plugin"), Some("register_ocr_backend"));
+    let spec = make_spec(&trait_def, &config, "Py", HashMap::new());
+    let result = gen_bridge_plugin_impl(&spec, &MockBridgeGenerator).expect("plugin impl");
+    assert!(
+        !result.contains("host_has"),
+        "no guard without the lifecycle hook:\n{result}"
+    );
+}

--- a/src/codegen/generators/trait_bridge/trait_impl.rs
+++ b/src/codegen/generators/trait_bridge/trait_impl.rs
@@ -1,27 +1,28 @@
-use super::{TraitBridgeGenerator, TraitBridgeSpec, format_param_type_with_lifetimes, format_return_type};
+use super::{
+    TraitBridgeGenerator, TraitBridgeSpec, default_delegate_name, forwarded_defaulted_methods, trait_method_signature,
+};
 
 pub fn gen_bridge_trait_impl(spec: &TraitBridgeSpec, generator: &dyn TraitBridgeGenerator) -> String {
     let wrapper = spec.wrapper_name();
     let trait_path = spec.trait_path();
 
-    // Check if the trait has async methods (needed for async_trait macro compatibility).
-    // Only own, required (non-default) methods need this check — those are the ones we emit.
-    let has_async_methods = spec
-        .trait_def
-        .methods
-        .iter()
-        .any(|m| m.is_async && m.trait_source.is_none() && !m.has_default_impl);
-    let async_trait_is_send = generator.async_trait_is_send();
-
-    // Filter out:
-    // - Methods inherited from super-traits (handled by gen_bridge_plugin_impl)
-    // - Methods with a default impl (let the trait's own default take effect)
+    // Own methods the bridge emits:
+    // - required methods (no default impl) — always emitted, host must provide them;
+    // - defaulted methods the generator opted in to forwarding — emitted with a
+    //   presence guard that falls back to the trait's default body via the
+    //   per-method delegate (see `gen_bridge_default_delegates`).
+    // Methods inherited from super-traits are handled by gen_bridge_plugin_impl.
+    let forwarded = forwarded_defaulted_methods(spec, generator);
     let own_methods: Vec<_> = spec
         .trait_def
         .methods
         .iter()
-        .filter(|m| m.trait_source.is_none() && !m.has_default_impl)
+        .filter(|m| m.trait_source.is_none() && (!m.has_default_impl || forwarded.iter().any(|f| f.name == m.name)))
         .collect();
+
+    // Check if the trait has async methods (needed for async_trait macro compatibility).
+    let has_async_methods = own_methods.iter().any(|m| m.is_async);
+    let async_trait_is_send = generator.async_trait_is_send();
 
     // Build method code with proper indentation
     let mut methods_code = String::with_capacity(1024);
@@ -30,54 +31,41 @@ pub fn gen_bridge_trait_impl(spec: &TraitBridgeSpec, generator: &dyn TraitBridge
             methods_code.push_str("\n\n");
         }
 
-        // Build the method signature
-        let async_kw = if method.is_async { "async " } else { "" };
-        let receiver = match &method.receiver {
-            Some(crate::core::ir::ReceiverKind::Ref) => "&self",
-            Some(crate::core::ir::ReceiverKind::RefMut) => "&mut self",
-            Some(crate::core::ir::ReceiverKind::Owned) => "self",
-            None => "",
-        };
-
-        // Build params (excluding self), using format_param_type_with_lifetimes to respect
-        // is_ref/is_mut and emit `<'_>` for core types that carry lifetime parameters.
-        let params: Vec<String> = method
-            .params
-            .iter()
-            .map(|p| {
-                format!(
-                    "{}: {}",
-                    p.name,
-                    format_param_type_with_lifetimes(p, &spec.type_paths, &spec.lifetime_type_names)
-                )
-            })
-            .collect();
-
-        let all_params = if receiver.is_empty() {
-            params.join(", ")
-        } else if params.is_empty() {
-            receiver.to_string()
-        } else {
-            format!("{}, {}", receiver, params.join(", "))
-        };
-
-        // Return type — override the IR's error type with the configured crate error type
-        // so the impl matches the actual trait definition (the IR may extract a different
-        // error type like anyhow::Error from re-exports or type alias resolution).
-        // Pass `returns_ref` so Vec<T> is emitted as `&[elem]` when the trait returns a slice.
-        let error_override = method.error_type.as_ref().map(|_| spec.error_path());
-        let ret = format_return_type(
-            &method.return_type,
-            error_override.as_deref(),
-            &spec.type_paths,
-            method.returns_ref,
-        );
+        // Build the method signature. Return type overrides the IR's error type with the
+        // configured crate error type so the impl matches the actual trait definition (the
+        // IR may extract a different error type like anyhow::Error from re-exports or type
+        // alias resolution); `returns_ref` makes Vec<T> emit as `&[elem]` for slice returns.
+        let sig = trait_method_signature(method, spec);
+        let (async_kw, all_params, ret) = (sig.async_kw, sig.all_params, sig.ret);
 
         // Generate body: async methods use Box::pin, sync methods call directly
-        let raw_body = if method.is_async {
+        let host_body = if method.is_async {
             generator.gen_async_method_body(method, spec)
         } else {
             generator.gen_sync_method_body(method, spec)
+        };
+
+        // Defaulted methods get a presence guard: when the host object doesn't define
+        // the method, fall back to the trait's genuine Rust default body through the
+        // per-method delegate instead of calling a missing host method.
+        let raw_body = match generator
+            .gen_method_presence_check(method, spec)
+            .filter(|_| method.has_default_impl)
+        {
+            Some(presence) => {
+                let guard = crate::codegen::template_env::render(
+                    "generators/trait_bridge/default_method_guard.jinja",
+                    minijinja::context! {
+                        presence => presence,
+                        delegate_name => default_delegate_name(spec, method),
+                        method_name => &method.name,
+                        arg_names => &sig.arg_names,
+                        is_async => method.is_async,
+                    },
+                );
+                format!("{guard}{host_body}")
+            }
+            None => host_body,
         };
 
         // When the trait method returns `&[&str]` (i.e. Vec<String> + returns_ref), the

--- a/src/codegen/generators/trait_bridge/wrapper.rs
+++ b/src/codegen/generators/trait_bridge/wrapper.rs
@@ -106,7 +106,12 @@ pub fn gen_bridge_plugin_impl(spec: &TraitBridgeSpec, generator: &dyn TraitBridg
         binding_exclusion_reason: None,
         version: Default::default(),
     };
-    let init_body = generator.gen_sync_method_body(&init_method, spec);
+    let mut init_body = generator.gen_sync_method_body(&init_method, spec);
+    // A host that doesn't define initialize() opted out of the lifecycle hook —
+    // treat it as a no-op instead of failing registration.
+    if let Some(presence) = generator.gen_lifecycle_presence_check(&init_method, spec) {
+        init_body = format!("if !({presence}) {{\n    return Ok(());\n}}\n{init_body}");
+    }
 
     // shutdown() -> Result<(), ErrorType>
     let shutdown_method = MethodDef {
@@ -128,7 +133,11 @@ pub fn gen_bridge_plugin_impl(spec: &TraitBridgeSpec, generator: &dyn TraitBridg
         binding_exclusion_reason: None,
         version: Default::default(),
     };
-    let shutdown_body = generator.gen_sync_method_body(&shutdown_method, spec);
+    let mut shutdown_body = generator.gen_sync_method_body(&shutdown_method, spec);
+    // Same no-op tolerance for shutdown() at unregistration.
+    if let Some(presence) = generator.gen_lifecycle_presence_check(&shutdown_method, spec) {
+        shutdown_body = format!("if !({presence}) {{\n    return Ok(());\n}}\n{shutdown_body}");
+    }
 
     // Split method bodies into lines for template iteration
     let version_lines: Vec<&str> = version_body.lines().collect();

--- a/src/codegen/generators/trait_bridge/wrapper.rs
+++ b/src/codegen/generators/trait_bridge/wrapper.rs
@@ -6,6 +6,12 @@ pub fn gen_bridge_wrapper_struct(spec: &TraitBridgeSpec, generator: &dyn TraitBr
     let wrapper = spec.wrapper_name();
     let foreign_type = generator.foreign_object_type();
 
+    let extra_fields: Vec<minijinja::Value> = generator
+        .extra_bridge_fields(spec)
+        .into_iter()
+        .map(|(name, ty)| minijinja::context! { name => name, ty => ty })
+        .collect();
+
     crate::codegen::template_env::render(
         "generators/trait_bridge/wrapper_struct.jinja",
         minijinja::context! {
@@ -13,6 +19,7 @@ pub fn gen_bridge_wrapper_struct(spec: &TraitBridgeSpec, generator: &dyn TraitBr
             trait_name => &spec.trait_def.name,
             wrapper_name => wrapper,
             foreign_type => foreign_type,
+            extra_fields => extra_fields,
         },
     )
 }

--- a/src/codegen/template_env.rs
+++ b/src/codegen/template_env.rs
@@ -449,6 +449,14 @@ static TEMPLATES: &[(&str, &str)] = &[
         "generators/trait_bridge/trait_method.jinja",
         include_str!("templates/generators/trait_bridge/trait_method.jinja"),
     ),
+    (
+        "generators/trait_bridge/default_method_guard.jinja",
+        include_str!("templates/generators/trait_bridge/default_method_guard.jinja"),
+    ),
+    (
+        "generators/trait_bridge/default_delegate.jinja",
+        include_str!("templates/generators/trait_bridge/default_delegate.jinja"),
+    ),
     ("doc_jsdoc_param.jinja", include_str!("templates/doc_jsdoc_param.jinja")),
     (
         "doc_jsdoc_param_desc.jinja",

--- a/src/codegen/templates/generators/trait_bridge/default_delegate.jinja
+++ b/src/codegen/templates/generators/trait_bridge/default_delegate.jinja
@@ -1,0 +1,46 @@
+/// Runs `{{ method_name }}`'s Rust default body for [`{{ wrapper_name }}`] while routing
+/// every other trait method back through the bridge, so the default body's `self.*`
+/// calls still reach host overrides.
+#[derive(Debug)]
+struct {{ delegate_name }}<'a>(&'a {{ wrapper_name }});
+
+{%- if super_trait_path %}
+
+impl {{ super_trait_path }} for {{ delegate_name }}<'_> {
+    fn name(&self) -> &str {
+        {{ super_trait_path }}::name(self.0)
+    }
+
+    fn version(&self) -> String {
+        {{ super_trait_path }}::version(self.0)
+    }
+
+    fn initialize(&self) -> std::result::Result<(), {{ error_path }}> {
+        {{ super_trait_path }}::initialize(self.0)
+    }
+
+    fn shutdown(&self) -> std::result::Result<(), {{ error_path }}> {
+        {{ super_trait_path }}::shutdown(self.0)
+    }
+}
+{%- endif %}
+
+{%- if has_async_methods %}
+{%- if async_trait_is_send %}
+
+#[async_trait::async_trait]
+{%- else %}
+
+#[async_trait::async_trait(?Send)]
+{%- endif %}
+{%- else %}
+{% endif %}
+impl {{ trait_path }} for {{ delegate_name }}<'_> {
+{%- for m in methods %}
+    {{ m.async_kw }}fn {{ m.name }}({{ m.all_params }}) -> {{ m.ret }} {
+        {{ m.forward_call }}
+    }
+{% if not loop.last %}
+{% endif %}
+{%- endfor %}
+}

--- a/src/codegen/templates/generators/trait_bridge/default_method_guard.jinja
+++ b/src/codegen/templates/generators/trait_bridge/default_method_guard.jinja
@@ -1,0 +1,3 @@
+if !({{ presence }}) {
+    return {{ delegate_name }}(self).{{ method_name }}({{ arg_names }}){% if is_async %}.await{% endif %};
+}

--- a/src/codegen/templates/generators/trait_bridge/wrapper_struct.jinja
+++ b/src/codegen/templates/generators/trait_bridge/wrapper_struct.jinja
@@ -2,4 +2,7 @@
 pub struct {{ wrapper_name }} {
     inner: {{ foreign_type }},
     cached_name: String,
+{%- for f in extra_fields %}
+    {{ f.name }}: {{ f.ty }},
+{%- endfor %}
 }

--- a/src/codegen/templates/generators/trait_bridge/wrapper_struct.jinja
+++ b/src/codegen/templates/generators/trait_bridge/wrapper_struct.jinja
@@ -2,7 +2,7 @@
 pub struct {{ wrapper_name }} {
     inner: {{ foreign_type }},
     cached_name: String,
-{%- for f in extra_fields %}
+{% for f in extra_fields %}
     {{ f.name }}: {{ f.ty }},
-{%- endfor %}
+{% endfor %}
 }

--- a/src/scaffold/languages/elixir.rs
+++ b/src/scaffold/languages/elixir.rs
@@ -659,7 +659,16 @@ end
   def register(impl_module) do
     plugin_name = impl_module.name()
     {{:ok, pid}} = start_link(impl_module)
-    {native_mod}.register_{trait_name_snake}(pid, plugin_name)
+
+    # Names of the functions the implementation module exports. Rust-defaulted
+    # trait methods outside this list keep their Rust default behavior instead
+    # of being dispatched to the module.
+    implemented_methods =
+      impl_module.__info__(:functions)
+      |> Enum.map(fn {{name, _arity}} -> Atom.to_string(name) end)
+      |> Enum.uniq()
+
+    {native_mod}.register_{trait_name_snake}(pid, plugin_name, implemented_methods)
   end
 end
 "#,

--- a/src/scaffold/tests/language_elixir.rs
+++ b/src/scaffold/tests/language_elixir.rs
@@ -352,8 +352,14 @@ fn test_scaffold_elixir_trait_bridge_registers_genserver_pid_and_plugin_name() {
         bridge_file.content.contains("plugin_name = impl_module.name()")
             && bridge_file
                 .content
-                .contains("DemoMarkup.Native.register_ocr_backend(pid, plugin_name)"),
+                .contains("DemoMarkup.Native.register_ocr_backend(pid, plugin_name, implemented_methods)"),
         "register/1 must require Plugin.name/0 and register the started GenServer pid; got:\n{}",
+        bridge_file.content
+    );
+    assert!(
+        bridge_file.content.contains("impl_module.__info__(:functions)"),
+        "register/1 must pass the implementation module's exported function names so \
+         Rust-defaulted trait methods outside the set keep their Rust default; got:\n{}",
         bridge_file.content
     );
     assert!(

--- a/src/scaffold/tests/language_php_dart.rs
+++ b/src/scaffold/tests/language_php_dart.rs
@@ -32,7 +32,10 @@ fn test_scaffold_php_omits_phpstan_and_cs_fixer_configs() {
         composers.len(),
         2,
         "expected root + package composer.json; got {:?}",
-        composers.iter().map(|f| f.path.display().to_string()).collect::<Vec<_>>()
+        composers
+            .iter()
+            .map(|f| f.path.display().to_string())
+            .collect::<Vec<_>>()
     );
     for composer in &composers {
         assert!(

--- a/src/scaffold/tests/poly.rs
+++ b/src/scaffold/tests/poly.rs
@@ -205,7 +205,10 @@ fn poly_toml_never_enables_system_native_formatters() {
         "[fmt.gleam.gleamfmt]",
         "[fmt.r.styler]",
     ] {
-        assert!(!c.contains(header), "{header} must NOT be enabled (pure-Rust policy); got:\n{c}");
+        assert!(
+            !c.contains(header),
+            "{header} must NOT be enabled (pure-Rust policy); got:\n{c}"
+        );
     }
 }
 
@@ -217,7 +220,10 @@ fn poly_toml_excludes_only_cargo_toml_from_formatting() {
     let c = &poly_toml(&files).content;
     // Cargo.toml is excluded (cargo sort owns it); Elixir is NOT excluded —
     // poly's tier-2 formats `.ex`/`.exs` now (no `mix format` residual).
-    assert!(c.contains("\"**/Cargo.toml\","), "Cargo.toml must be excluded from poly; got:\n{c}");
+    assert!(
+        c.contains("\"**/Cargo.toml\","),
+        "Cargo.toml must be excluded from poly; got:\n{c}"
+    );
     assert!(
         !c.contains("packages/elixir/**/*.ex"),
         "Elixir must NOT be excluded (poly tier-2 formats it now); got:\n{c}"

--- a/tests/backend_visitor_result_policy_test.rs
+++ b/tests/backend_visitor_result_policy_test.rs
@@ -223,6 +223,7 @@ fn visitor_result_policy_is_metadata_driven_for_napi_wasm_pyo3_magnus_extendr_an
         "Error",
         "Error::from({msg})",
         &api,
+        &[],
     )
     .expect("pyo3 visitor bridge should generate");
     assert_metadata_driven(&pyo3.code);
@@ -299,6 +300,7 @@ fn visitor_callbacks_are_filtered_by_configured_context_and_result_for_dynamic_b
         "Error",
         "Error::from({msg})",
         &api,
+        &[],
     )
     .expect("pyo3 visitor bridge should generate");
     assert_filtered_callback_surface(&pyo3.code, "PySyntaxWalkerBridge");

--- a/tests/backends_magnus_gen_stubs_test.rs
+++ b/tests/backends_magnus_gen_stubs_test.rs
@@ -1197,3 +1197,66 @@ fn test_rbs_plugin_bridge_emits_typed_interface_and_typed_register() {
         "register fn must type its backend param against the interface:\n{content}"
     );
 }
+
+#[test]
+fn test_rbs_plugin_interface_omits_defaulted_methods_and_documents_them() {
+    // RBS interfaces can't express optional members, so Rust-defaulted methods
+    // must not be required interface members — the runtime bridge forwards them
+    // only when the host defines them.
+    let backend = MagnusBackend;
+    let mut config = make_config_with_stubs();
+    config.trait_bridges = vec![alef::core::config::TraitBridgeConfig {
+        trait_name: "Greeter".to_string(),
+        register_fn: Some("register_greeter".to_string()),
+        registry_getter: Some("test_lib::registry::get".to_string()),
+        super_trait: Some("Plugin".to_string()),
+        ..Default::default()
+    }];
+
+    let greeter = TypeDef {
+        name: "Greeter".to_string(),
+        rust_path: "test_lib::Greeter".to_string(),
+        is_trait: true,
+        is_opaque: true,
+        methods: vec![
+            MethodDef {
+                name: "process".to_string(),
+                params: vec![],
+                return_type: TypeRef::String,
+                receiver: Some(ReceiverKind::Ref),
+                ..Default::default()
+            },
+            MethodDef {
+                name: "supports_table_detection".to_string(),
+                params: vec![],
+                return_type: TypeRef::Primitive(PrimitiveType::Bool),
+                receiver: Some(ReceiverKind::Ref),
+                has_default_impl: true,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let api = ApiSurface {
+        crate_name: "test_lib".to_string(),
+        version: "0.1.0".to_string(),
+        types: vec![greeter],
+        ..Default::default()
+    };
+
+    let content = backend.generate_type_stubs(&api, &config).unwrap()[0].content.clone();
+
+    assert!(
+        content.contains("def process:"),
+        "required method must stay in the interface:\n{content}"
+    );
+    assert!(
+        !content.contains("def supports_table_detection:"),
+        "Rust-defaulted method must not be a required interface member:\n{content}"
+    );
+    assert!(
+        content.contains("Optional methods") && content.contains("supports_table_detection"),
+        "defaulted method must be documented as optional:\n{content}"
+    );
+}

--- a/tests/backends_pyo3_gen_bindings/options_exports.rs
+++ b/tests/backends_pyo3_gen_bindings/options_exports.rs
@@ -613,3 +613,65 @@ fn test_typeddict_style_reexports_only_listed_results_as_native() {
         "is_return_type-but-not-reexported config must come from .options, not native:\n{init_py}"
     );
 }
+
+#[test]
+fn test_options_py_emits_from_native_converters_with_nested_recursion() {
+    // Every emitted options dataclass gets a `_from_native_<snake>` converter so
+    // trait-callback bridges can hand hosts the public dataclass; nested dataclass
+    // fields recurse (including through Optional).
+    let backend = Pyo3Backend;
+
+    let inner = TypeDef {
+        name: "InnerConfig".to_string(),
+        rust_path: "my_lib::InnerConfig".to_string(),
+        has_serde: true,
+        has_default: true,
+        fields: vec![make_field("depth", TypeRef::Primitive(PrimitiveType::U32), false)],
+        ..Default::default()
+    };
+    let outer = TypeDef {
+        name: "OuterConfig".to_string(),
+        rust_path: "my_lib::OuterConfig".to_string(),
+        has_serde: true,
+        has_default: true,
+        fields: vec![
+            make_field("label", TypeRef::String, false),
+            make_field(
+                "inner",
+                TypeRef::Optional(Box::new(TypeRef::Named("InnerConfig".to_string()))),
+                true,
+            ),
+        ],
+        ..Default::default()
+    };
+
+    let api = ApiSurface {
+        crate_name: "my-lib".to_string(),
+        version: "1.0.0".to_string(),
+        types: vec![inner, outer],
+        ..Default::default()
+    };
+    let config = make_config();
+
+    let files = backend
+        .generate_public_api(&api, &config)
+        .expect("generate_public_api failed");
+    let options = files
+        .iter()
+        .find(|f| f.path.to_string_lossy().ends_with("options.py"))
+        .expect("options.py should be generated");
+    let content = &options.content;
+
+    assert!(
+        content.contains("def _from_native_outer_config(native: Any) -> OuterConfig:"),
+        "converter must be emitted per dataclass:\n{content}"
+    );
+    assert!(
+        content.contains("label=native.label,"),
+        "plain fields pass through:\n{content}"
+    );
+    assert!(
+        content.contains("inner=(None if native.inner is None else _from_native_inner_config(native.inner)),"),
+        "nested dataclass fields must recurse through Optional:\n{content}"
+    );
+}

--- a/tests/backends_pyo3_gen_bindings/options_exports.rs
+++ b/tests/backends_pyo3_gen_bindings/options_exports.rs
@@ -675,3 +675,50 @@ fn test_options_py_emits_from_native_converters_with_nested_recursion() {
         "nested dataclass fields must recurse through Optional:\n{content}"
     );
 }
+
+#[test]
+fn test_from_native_converter_guards_optional_flag_fields() {
+    // Config fields are typically `Named` + `optional: true` in the IR (not
+    // `TypeRef::Optional`) — the converter must still None-guard the recursion,
+    // or a default config with a None nested section crashes the lift.
+    let backend = Pyo3Backend;
+
+    let inner = TypeDef {
+        name: "InnerConfig".to_string(),
+        rust_path: "my_lib::InnerConfig".to_string(),
+        has_serde: true,
+        has_default: true,
+        fields: vec![make_field("depth", TypeRef::Primitive(PrimitiveType::U32), false)],
+        ..Default::default()
+    };
+    let outer = TypeDef {
+        name: "OuterConfig".to_string(),
+        rust_path: "my_lib::OuterConfig".to_string(),
+        has_serde: true,
+        has_default: true,
+        fields: vec![make_field("inner", TypeRef::Named("InnerConfig".to_string()), true)],
+        ..Default::default()
+    };
+
+    let api = ApiSurface {
+        crate_name: "my-lib".to_string(),
+        version: "1.0.0".to_string(),
+        types: vec![inner, outer],
+        ..Default::default()
+    };
+    let config = make_config();
+
+    let files = backend
+        .generate_public_api(&api, &config)
+        .expect("generate_public_api failed");
+    let options = files
+        .iter()
+        .find(|f| f.path.to_string_lossy().ends_with("options.py"))
+        .expect("options.py should be generated");
+    let content = &options.content;
+
+    assert!(
+        content.contains("inner=(None if native.inner is None else _from_native_inner_config(native.inner)),"),
+        "optional-flag nested fields must be None-guarded:\n{content}"
+    );
+}

--- a/tests/backends_pyo3_gen_bindings/trait_bridge_generation.rs
+++ b/tests/backends_pyo3_gen_bindings/trait_bridge_generation.rs
@@ -37,7 +37,6 @@ fn test_gen_trait_bridge_produces_non_empty_output_for_plugin_pattern() {
         "Error",
         "Error::from({msg})",
         &api,
-        "my_lib",
         &[],
     )
     .expect("trait bridge generation should succeed");
@@ -90,7 +89,6 @@ fn test_gen_trait_bridge_wrapper_struct_has_required_fields() {
         "Error",
         "Error::from({msg})",
         &api,
-        "my_lib",
         &[],
     )
     .expect("trait bridge generation should succeed");
@@ -139,7 +137,6 @@ fn test_gen_trait_bridge_generates_registration_fn_when_configured() {
         "Error",
         "Error::from({msg})",
         &api,
-        "my_lib",
         &[],
     )
     .expect("trait bridge generation should succeed");
@@ -200,7 +197,6 @@ fn test_gen_trait_bridge_with_sync_and_async_required_methods() {
         "Error",
         "Error::from({msg})",
         &api,
-        "my_lib",
         &[],
     )
     .expect("trait bridge generation should succeed");

--- a/tests/backends_pyo3_gen_bindings/trait_bridge_generation.rs
+++ b/tests/backends_pyo3_gen_bindings/trait_bridge_generation.rs
@@ -30,8 +30,17 @@ fn test_gen_trait_bridge_produces_non_empty_output_for_plugin_pattern() {
     };
     let api = make_api_surface();
 
-    let code = gen_trait_bridge(&trait_def, &bridge_cfg, "my_lib", "Error", "Error::from({msg})", &api)
-        .expect("trait bridge generation should succeed");
+    let code = gen_trait_bridge(
+        &trait_def,
+        &bridge_cfg,
+        "my_lib",
+        "Error",
+        "Error::from({msg})",
+        &api,
+        "my_lib",
+        &[],
+    )
+    .expect("trait bridge generation should succeed");
 
     assert!(!code.code.is_empty(), "gen_trait_bridge must produce non-empty output");
     assert!(
@@ -74,8 +83,17 @@ fn test_gen_trait_bridge_wrapper_struct_has_required_fields() {
     };
     let api = make_api_surface();
 
-    let code = gen_trait_bridge(&trait_def, &bridge_cfg, "my_lib", "Error", "Error::from({msg})", &api)
-        .expect("trait bridge generation should succeed");
+    let code = gen_trait_bridge(
+        &trait_def,
+        &bridge_cfg,
+        "my_lib",
+        "Error",
+        "Error::from({msg})",
+        &api,
+        "my_lib",
+        &[],
+    )
+    .expect("trait bridge generation should succeed");
 
     // The wrapper struct must hold the Python object and a cached name field
     assert!(
@@ -114,8 +132,17 @@ fn test_gen_trait_bridge_generates_registration_fn_when_configured() {
     };
     let api = make_api_surface();
 
-    let code = gen_trait_bridge(&trait_def, &bridge_cfg, "my_lib", "Error", "Error::from({msg})", &api)
-        .expect("trait bridge generation should succeed");
+    let code = gen_trait_bridge(
+        &trait_def,
+        &bridge_cfg,
+        "my_lib",
+        "Error",
+        "Error::from({msg})",
+        &api,
+        "my_lib",
+        &[],
+    )
+    .expect("trait bridge generation should succeed");
 
     assert!(
         code.code.contains("fn register_inference_backend"),
@@ -166,8 +193,17 @@ fn test_gen_trait_bridge_with_sync_and_async_required_methods() {
     };
     let api = make_api_surface();
 
-    let code = gen_trait_bridge(&trait_def, &bridge_cfg, "my_lib", "Error", "Error::from({msg})", &api)
-        .expect("trait bridge generation should succeed");
+    let code = gen_trait_bridge(
+        &trait_def,
+        &bridge_cfg,
+        "my_lib",
+        "Error",
+        "Error::from({msg})",
+        &api,
+        "my_lib",
+        &[],
+    )
+    .expect("trait bridge generation should succeed");
 
     assert!(!code.code.is_empty(), "output must not be empty");
     // Sync method body uses Python::attach (no spawn_blocking)

--- a/tests/backends_pyo3_gen_bindings/trait_bridge_methods.rs
+++ b/tests/backends_pyo3_gen_bindings/trait_bridge_methods.rs
@@ -250,6 +250,7 @@ fn make_struct_aware_generator(core_import: &str, struct_params: &[&str]) -> Pyo
         error_type: "Error".to_string(),
         struct_param_types: struct_params.iter().map(|s| s.to_string()).collect(),
         struct_return_types: std::collections::HashSet::new(),
+        forwardable_defaulted: std::collections::HashSet::new(),
     }
 }
 
@@ -354,5 +355,111 @@ fn test_enum_and_unknown_params_keep_json_string_representation() {
     assert!(
         !sync_body.contains("Mood::from(") && !sync_body.contains("Widget::from("),
         "non-struct Named params must NOT be constructed as native objects:\n{sync_body}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Defaulted-method forwarding
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_defaulted_method_forwarded_with_hasattr_guard_and_delegate() {
+    let mut generator = make_bridge_generator("my_lib");
+    generator
+        .forwardable_defaulted
+        .insert("supports_table_detection".to_string());
+
+    let methods = vec![
+        make_method_def(
+            "supports_language",
+            vec![],
+            TypeRef::Primitive(PrimitiveType::Bool),
+            false,
+            false,
+            false,
+        ),
+        make_method_def(
+            "supports_table_detection",
+            vec![],
+            TypeRef::Primitive(PrimitiveType::Bool),
+            false,
+            false,
+            true,
+        ),
+    ];
+    let trait_def = make_trait_def("OcrBackend", "my_lib::OcrBackend", methods);
+    let bridge_cfg = make_bridge_cfg("OcrBackend");
+    let spec = TraitBridgeSpec {
+        trait_def: &trait_def,
+        bridge_config: &bridge_cfg,
+        core_import: "my_lib",
+        wrapper_prefix: "Py",
+        type_paths: HashMap::new(),
+        lifetime_type_names: std::collections::HashSet::new(),
+        error_type: "Error".to_string(),
+        error_constructor: "Error::from({msg})".to_string(),
+    };
+
+    let output = alef::codegen::generators::trait_bridge::gen_bridge_all(&spec, &generator);
+    let code = &output.code;
+
+    assert!(
+        code.contains("fn supports_table_detection"),
+        "opted-in defaulted method must be emitted:\n{code}"
+    );
+    assert!(
+        code.contains("hasattr(\"supports_table_detection\")"),
+        "guard must check the Python object with hasattr:\n{code}"
+    );
+    assert!(
+        code.contains("PyOcrBackendBridgeDefaultSupportsTableDetection(self).supports_table_detection()"),
+        "fallback must run the Rust default body via the delegate:\n{code}"
+    );
+    assert!(
+        code.contains("struct PyOcrBackendBridgeDefaultSupportsTableDetection"),
+        "delegate type must be emitted:\n{code}"
+    );
+}
+
+#[test]
+fn test_defaulted_method_not_in_forwardable_set_stays_omitted() {
+    let generator = make_bridge_generator("my_lib");
+
+    let methods = vec![
+        make_method_def(
+            "supports_language",
+            vec![],
+            TypeRef::Primitive(PrimitiveType::Bool),
+            false,
+            false,
+            false,
+        ),
+        make_method_def(
+            "supports_table_detection",
+            vec![],
+            TypeRef::Primitive(PrimitiveType::Bool),
+            false,
+            false,
+            true,
+        ),
+    ];
+    let trait_def = make_trait_def("OcrBackend", "my_lib::OcrBackend", methods);
+    let bridge_cfg = make_bridge_cfg("OcrBackend");
+    let spec = TraitBridgeSpec {
+        trait_def: &trait_def,
+        bridge_config: &bridge_cfg,
+        core_import: "my_lib",
+        wrapper_prefix: "Py",
+        type_paths: HashMap::new(),
+        lifetime_type_names: std::collections::HashSet::new(),
+        error_type: "Error".to_string(),
+        error_constructor: "Error::from({msg})".to_string(),
+    };
+
+    let output = alef::codegen::generators::trait_bridge::gen_bridge_all(&spec, &generator);
+    assert!(
+        !output.code.contains("fn supports_table_detection"),
+        "defaulted method outside the forwardable set must stay omitted:\n{}",
+        output.code
     );
 }

--- a/tests/backends_pyo3_gen_bindings/trait_bridge_methods.rs
+++ b/tests/backends_pyo3_gen_bindings/trait_bridge_methods.rs
@@ -251,6 +251,7 @@ fn make_struct_aware_generator(core_import: &str, struct_params: &[&str]) -> Pyo
         struct_param_types: struct_params.iter().map(|s| s.to_string()).collect(),
         struct_return_types: std::collections::HashSet::new(),
         forwardable_defaulted: std::collections::HashSet::new(),
+        options_dataclass_types: std::collections::HashSet::new(),
     }
 }
 
@@ -461,5 +462,54 @@ fn test_defaulted_method_not_in_forwardable_set_stays_omitted() {
         !output.code.contains("fn supports_table_detection"),
         "defaulted method outside the forwardable set must stay omitted:\n{}",
         output.code
+    );
+}
+
+#[test]
+fn test_options_dataclass_param_lifted_before_host_call() {
+    let mut generator = make_bridge_generator("my_lib");
+    generator.struct_param_types.insert("GreetConfig".to_string());
+    generator.options_dataclass_types.insert("GreetConfig".to_string());
+
+    let trait_def = make_trait_def("Greeter", "my_lib::Greeter", vec![]);
+    let bridge_cfg = make_bridge_cfg("Greeter");
+    let spec = TraitBridgeSpec {
+        trait_def: &trait_def,
+        bridge_config: &bridge_cfg,
+        core_import: "my_lib",
+        wrapper_prefix: "Py",
+        type_paths: HashMap::new(),
+        lifetime_type_names: std::collections::HashSet::new(),
+        error_type: "Error".to_string(),
+        error_constructor: "Error::from({msg})".to_string(),
+    };
+    let method = make_method_def(
+        "process",
+        vec![ParamDef {
+            name: "config".to_string(),
+            ty: TypeRef::Named("GreetConfig".to_string()),
+            is_ref: true,
+            ..Default::default()
+        }],
+        TypeRef::String,
+        false,
+        false,
+        false,
+    );
+
+    let body = generator.gen_sync_method_body(&method, &spec);
+    assert!(
+        body.contains(
+            "__alef_options_from_native(py, \"_from_native_greet_config\", GreetConfig::from((*config).clone()))"
+        ),
+        "options-dataclass params must be lifted via the generated converter:\n{body}"
+    );
+
+    // Without the options classification the native object is passed directly.
+    generator.options_dataclass_types.clear();
+    let body = generator.gen_sync_method_body(&method, &spec);
+    assert!(
+        !body.contains("__alef_options_from_native"),
+        "non-options structs must keep the native object:\n{body}"
     );
 }

--- a/tests/backends_pyo3_gen_bindings_test.rs
+++ b/tests/backends_pyo3_gen_bindings_test.rs
@@ -140,6 +140,7 @@ fn make_bridge_generator(core_import: &str) -> Pyo3BridgeGenerator {
         struct_param_types: std::collections::HashSet::new(),
         struct_return_types: std::collections::HashSet::new(),
         forwardable_defaulted: std::collections::HashSet::new(),
+        options_dataclass_types: std::collections::HashSet::new(),
     }
 }
 

--- a/tests/backends_pyo3_gen_bindings_test.rs
+++ b/tests/backends_pyo3_gen_bindings_test.rs
@@ -139,6 +139,7 @@ fn make_bridge_generator(core_import: &str) -> Pyo3BridgeGenerator {
         error_type: "Error".to_string(),
         struct_param_types: std::collections::HashSet::new(),
         struct_return_types: std::collections::HashSet::new(),
+        forwardable_defaulted: std::collections::HashSet::new(),
     }
 }
 

--- a/tests/backends_pyo3_gen_stubs_test.rs
+++ b/tests/backends_pyo3_gen_stubs_test.rs
@@ -2090,3 +2090,75 @@ fn test_pyi_plugin_bridge_emits_typed_protocol_and_typed_register() {
         "register fn must type its backend param against the Protocol:\n{content}"
     );
 }
+
+#[test]
+fn test_pyi_plugin_protocol_omits_defaulted_methods_and_documents_them() {
+    // Plugin trait with one required and one Rust-defaulted method: the Protocol
+    // must require only the former (the runtime contract) and document the latter
+    // as optional — a minimal, valid backend must conform structurally.
+    let backend = Pyo3Backend;
+    let mut config = make_config_with_stubs();
+    config.trait_bridges = vec![alef::core::config::TraitBridgeConfig {
+        trait_name: "Greeter".to_string(),
+        register_fn: Some("register_greeter".to_string()),
+        registry_getter: Some("test_lib::registry::get".to_string()),
+        super_trait: Some("Plugin".to_string()),
+        bind_via: alef::core::config::BridgeBinding::FunctionParam,
+        ..Default::default()
+    }];
+
+    let greeter = TypeDef {
+        name: "Greeter".to_string(),
+        rust_path: "test_lib::Greeter".to_string(),
+        is_trait: true,
+        is_opaque: true,
+        methods: vec![
+            MethodDef {
+                name: "process".to_string(),
+                params: vec![],
+                return_type: TypeRef::String,
+                receiver: Some(ReceiverKind::Ref),
+                ..Default::default()
+            },
+            MethodDef {
+                name: "supports_table_detection".to_string(),
+                params: vec![],
+                return_type: TypeRef::Primitive(PrimitiveType::Bool),
+                receiver: Some(ReceiverKind::Ref),
+                has_default_impl: true,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let api = ApiSurface {
+        crate_name: "test_lib".to_string(),
+        version: "0.1.0".to_string(),
+        types: vec![greeter],
+        ..Default::default()
+    };
+
+    let content = backend.generate_type_stubs(&api, &config).unwrap()[0].content.clone();
+
+    assert!(
+        content.contains("class Greeter(Protocol):"),
+        "plugin bridge must emit a Protocol:\n{content}"
+    );
+    assert!(
+        content.contains("def process(self)"),
+        "required method must stay in the Protocol:\n{content}"
+    );
+    assert!(
+        !content.contains("def supports_table_detection"),
+        "Rust-defaulted method must not be a required Protocol member:\n{content}"
+    );
+    assert!(
+        content.contains("`supports_table_detection`") && content.contains("Optional methods"),
+        "defaulted method must be documented as optional:\n{content}"
+    );
+    assert!(
+        content.contains("`initialize()`"),
+        "lifecycle hooks must be documented as optional:\n{content}"
+    );
+}

--- a/tests/backends_pyo3_gen_stubs_test.rs
+++ b/tests/backends_pyo3_gen_stubs_test.rs
@@ -2162,3 +2162,61 @@ fn test_pyi_plugin_protocol_omits_defaulted_methods_and_documents_them() {
         "lifecycle hooks must be documented as optional:\n{content}"
     );
 }
+
+#[test]
+fn test_pyi_plugin_protocol_types_config_params_as_options_dataclass() {
+    // A config struct exported as an options dataclass must appear as `options.X`
+    // in plugin Protocol params — the type the package exports is the type the
+    // bridge passes to the host.
+    let backend = Pyo3Backend;
+    let mut config = make_config_with_stubs();
+    config.trait_bridges = vec![alef::core::config::TraitBridgeConfig {
+        trait_name: "Greeter".to_string(),
+        register_fn: Some("register_greeter".to_string()),
+        registry_getter: Some("test_lib::registry::get".to_string()),
+        super_trait: Some("Plugin".to_string()),
+        bind_via: alef::core::config::BridgeBinding::FunctionParam,
+        ..Default::default()
+    }];
+
+    let greeter = TypeDef {
+        name: "Greeter".to_string(),
+        rust_path: "test_lib::Greeter".to_string(),
+        is_trait: true,
+        is_opaque: true,
+        methods: vec![MethodDef {
+            name: "process".to_string(),
+            params: vec![ParamDef {
+                name: "config".to_string(),
+                ty: TypeRef::Named("GreetConfig".to_string()),
+                is_ref: true,
+                ..Default::default()
+            }],
+            return_type: TypeRef::String,
+            receiver: Some(ReceiverKind::Ref),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let greet_config = TypeDef {
+        name: "GreetConfig".to_string(),
+        rust_path: "test_lib::GreetConfig".to_string(),
+        has_serde: true,
+        has_default: true,
+        fields: vec![make_field("label", TypeRef::String, false)],
+        ..Default::default()
+    };
+
+    let api = ApiSurface {
+        crate_name: "test_lib".to_string(),
+        version: "0.1.0".to_string(),
+        types: vec![greeter, greet_config],
+        ..Default::default()
+    };
+
+    let content = backend.generate_type_stubs(&api, &config).unwrap()[0].content.clone();
+    assert!(
+        content.contains("def process(self, config: options.GreetConfig)"),
+        "plugin Protocol must type options-dataclass config params as options.X:\n{content}"
+    );
+}

--- a/tests/backends_rustler_gen_public_api_test.rs
+++ b/tests/backends_rustler_gen_public_api_test.rs
@@ -2051,3 +2051,91 @@ fn test_visitor_bridge_does_not_emit_host_behaviour() {
         main.content
     );
 }
+
+#[test]
+fn test_trait_behaviour_callback_params_are_maps_with_optional_callbacks() {
+    // Callback direction: the bridge hands the host a native Erlang map for struct
+    // params — the input-direction "config as optional JSON string" convention must
+    // not leak into @callback specs. Rust-defaulted methods and the lifecycle hooks
+    // are @optional_callbacks.
+    let backend = RustlerBackend;
+
+    let ocr_config = TypeDef {
+        name: "OcrConfig".to_string(),
+        rust_path: "my_lib::OcrConfig".to_string(),
+        has_serde: true,
+        has_default: true,
+        fields: vec![make_field("language", TypeRef::String, false)],
+        ..Default::default()
+    };
+    let trait_def = TypeDef {
+        name: "OcrBackend".to_string(),
+        rust_path: "my_lib::OcrBackend".to_string(),
+        is_trait: true,
+        is_opaque: true,
+        methods: vec![
+            MethodDef {
+                name: "process_image".to_string(),
+                params: vec![ParamDef {
+                    name: "config".to_string(),
+                    ty: TypeRef::Named("OcrConfig".to_string()),
+                    is_ref: true,
+                    ..Default::default()
+                }],
+                return_type: TypeRef::Named("OcrConfig".to_string()),
+                receiver: Some(alef::core::ir::ReceiverKind::Ref),
+                error_type: Some("Error".to_string()),
+                ..Default::default()
+            },
+            MethodDef {
+                name: "supports_table_detection".to_string(),
+                params: vec![],
+                return_type: TypeRef::Primitive(PrimitiveType::Bool),
+                receiver: Some(alef::core::ir::ReceiverKind::Ref),
+                has_default_impl: true,
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let api = ApiSurface {
+        crate_name: "my-lib".to_string(),
+        version: "1.0.0".to_string(),
+        types: vec![ocr_config, trait_def],
+        ..Default::default()
+    };
+    let mut config = make_config("my_lib");
+    config.trait_bridges = vec![TraitBridgeConfig {
+        trait_name: "OcrBackend".to_string(),
+        super_trait: Some("Plugin".to_string()),
+        registry_getter: Some("my_lib::get_registry".to_string()),
+        register_fn: Some("register_ocr_backend".to_string()),
+        bind_via: BridgeBinding::FunctionParam,
+        ..Default::default()
+    }];
+
+    let files = backend.generate_public_api(&api, &config).unwrap();
+    let main = files
+        .iter()
+        .find(|f| f.path.to_string_lossy().replace('\\', "/").ends_with("my_lib.ex"))
+        .expect("my_lib.ex should be generated");
+    let content = &main.content;
+
+    assert!(
+        content.contains("@callback process_image(map())"),
+        "callback struct param must be map(), not the input-direction JSON string; got:\n{content}"
+    );
+    assert!(
+        !content.contains("@callback process_image(String.t() | nil)"),
+        "stale JSON-string spec must be gone; got:\n{content}"
+    );
+    assert!(
+        content.contains("@callback initialize() :: any()") && content.contains("@callback shutdown() :: any()"),
+        "lifecycle hooks must be declared; got:\n{content}"
+    );
+    assert!(
+        content.contains("@optional_callbacks [supports_table_detection: 0, initialize: 0, shutdown: 0]"),
+        "defaulted + lifecycle methods must be optional callbacks; got:\n{content}"
+    );
+}

--- a/tests/backends_rustler_gen_public_api_test.rs
+++ b/tests/backends_rustler_gen_public_api_test.rs
@@ -2017,8 +2017,9 @@ fn test_plugin_bridge_emits_typed_host_behaviour() {
 
     // register_* delegate references the behaviour for the host to implement.
     assert!(
-        content.contains("def register_greeter(genserver_pid, plugin_name) do") && content.contains("Greeter.Host"),
-        "register delegate must reference the host behaviour; got:\n{content}"
+        content.contains("def register_greeter(genserver_pid, plugin_name, implemented_methods \\\\ []) do")
+            && content.contains("Greeter.Host"),
+        "register delegate must reference the host behaviour and default the exports list; got:\n{content}"
     );
 }
 

--- a/tests/backends_rustler_trait_bridge_test.rs
+++ b/tests/backends_rustler_trait_bridge_test.rs
@@ -361,10 +361,10 @@ fn test_plugin_bridge_generates_registration_fn() {
     );
     assert!(
         code.code
-            .contains("genserver_pid: rustler::LocalPid, plugin_name: String")
+            .contains("genserver_pid: rustler::LocalPid, plugin_name: String, implemented_methods: Vec<String>")
             && code
                 .code
-                .contains("RustlerTextBackendBridge::new(genserver_pid, plugin_name)"),
+                .contains("RustlerTextBackendBridge::new(genserver_pid, plugin_name, implemented_methods)"),
         "registration fn must store the provided GenServer pid and require a plugin name, got:\n{}",
         code.code
     );


### PR DESCRIPTION
Fixes #165. Fixes #166. Fixes #167. Fixes #168.

## What this changes

Custom plugin backends written in the dynamic binding languages don't get the contract the Rust trait promises. A host implementation of a Rust-defaulted method (`supports_table_detection`, `process_document`, `should_process`, …) is silently never called; the generated typed surfaces require those same methods anyway while omitting the lifecycle methods the bridge does call; registration hard-fails on a missing `initialize` (and on Ruby it invokes the host's **constructor**, since that's what `initialize` is there); and on Python the Protocol names a config type the package doesn't publicly export.

After this PR the bridges, the typed surfaces, and the Rust trait agree:

- **Bridges forward Rust-defaulted methods** when the host implements them, and fall back to the genuine Rust default body otherwise — pyo3, magnus, php, napi, wasm, rustler, extendr. (ffi's vtable and dart already forwarded; jni is excluded because its trait-bridge registration is still a marshalling-free stub upstream.)
- **Typed surfaces list the real contract.** Rust-defaulted methods are no longer required members: the Python Protocol and Ruby RBS interface narrow to the required set (with the optional surface documented), the PHP interface stops hard-requiring methods the bridge never needed, Elixir behaviours gain `@optional_callbacks` plus `initialize`/`shutdown` callbacks, and Node plugin interfaces declare the optional lifecycle hooks.
- **A missing `initialize`/`shutdown` is a no-op** instead of a registration/unregistration failure (napi already behaved this way; the other backends now match). On magnus the bridge no longer invokes `initialize` at all unless the host explicitly exposes a public one — `respond_to(..., false)` excludes private methods, and Ruby constructors are private, so host constructors are never re-run at registration.
- **pyo3 config params are the public type.** Callback config structs the package exports as options dataclasses are lifted from the native pyclass into the dataclass (via generated `options._from_native_*` converters) before the host is invoked, and plugin Protocols type those params as `options.X` — the type the docs hand an implementer is the type the Protocol accepts and the type that arrives at runtime.
- **rustler behaviour specs describe reality**: natively-marshalled struct params are `map()`, not the stale input-direction `String.t() | nil`.

## How

The shared trait-bridge generator grew two opt-in hooks. `gen_method_presence_check` returns a per-backend "does the host define this method" expression; when a backend opts a defaulted method in, the bridge emits it with a guard that calls the host when present and otherwise delegates to the trait's genuine Rust default body. The fallback runs through a per-method delegate type (`WrapperDefaultX`) that routes every *other* trait method — and the `Plugin` super-trait — back through the bridge, so a default body's `self.*` calls still reach host overrides. `gen_lifecycle_presence_check` guards the synthesized `initialize`/`shutdown` bodies the same way, falling back to `Ok(())`.

Presence detection is per-backend: pyo3 checks `hasattr` at call time, php looks the method up on the class (`zend::Function::try_from_method` — an existence check, not an invocation), wasm uses `Reflect`. magnus, extendr, and napi capture flags at construction (Ruby objects can't be probed off the GVL, R objects only exist on the R main thread, JS objects only on the event loop). rustler can't probe an Elixir module from Rust at all, so the scaffolded bridge module's `register/1` now passes the implementation module's exported function names (`__info__(:functions)`) through a new third registration argument; the generated Elixir delegate defaults it to `[]`, so existing two-arg callers keep today's behavior.

Backends that don't opt in keep their previous emission byte-for-byte, and the plugin Protocol/interface narrowing does not touch visitor-style (options-field) bridges.

Verified end-to-end against a consumer regeneration: the regenerated pyo3, napi, php, wasm, magnus, and rustler binding crates all compile, the OCR plugin Protocol narrows to `process_image` / `supports_language` / `backend_type` with `config: options.OcrConfig`, and the Elixir behaviour emits `map()` specs with the expected `@optional_callbacks`.

One seam intentionally left: config structs that are *also* return types (e.g. a consumer's main extraction config) are TypedDict-classified rather than options dataclasses, so their Protocol params keep the native class. Unifying those needs a per-consumer decision (re-export the native class, or lift to dicts and change host attribute access) — tracked in #165's discussion rather than forced here.
