### PR TITLE
chore(release): 0.30.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.19] - 2026-07-04
+
 ### Fixed
 
 - **trait-bridge**: dynamic-backend bridges (pyo3, magnus, php, napi, wasm,
@@ -29,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Protocol (#165).
 - **rustler**: behaviour `@callback` specs now declare natively-marshalled
   struct params as `map()` instead of the stale JSON `String.t()` (#168).
-
 ## [0.30.18] - 2026-07-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "alef"
-version = "0.30.18"
+version = "0.30.19"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "alef"
-version = "0.30.18"
+version = "0.30.19"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/alef.toml
+++ b/alef.toml
@@ -1,5 +1,5 @@
 [workspace]
-alef_version = "0.30.18"
+alef_version = "0.30.19"
 languages = []
 
 [workspace.dto]

--- a/schemas/alef.schema.json
+++ b/schemas/alef.schema.json
@@ -7433,7 +7433,7 @@
       "type": "object"
     }
   },
-  "$id": "https://github.com/xberg-io/alef/releases/download/v0.30.18/alef.schema.json",
+  "$id": "https://github.com/xberg-io/alef/releases/download/v0.30.19/alef.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "description": "JSON Schema for the JSON representation of alef.toml.",
@@ -7552,6 +7552,6 @@
   ],
   "title": "Alef configuration",
   "type": "object",
-  "version": "0.30.18",
-  "x-alef-version": "0.30.18"
+  "version": "0.30.19",
+  "x-alef-version": "0.30.19"
 }

--- a/src/core/template_versions.rs
+++ b/src/core/template_versions.rs
@@ -442,5 +442,5 @@ pub mod cran {
 pub mod precommit {
     // alef rev: managed by sync-versions hook, no renovate marker. Folded into
     // the generated `alef:hash:` inputs digest (see `core::hash`).
-    pub const ALEF_REV: &str = "v0.30.18";
+    pub const ALEF_REV: &str = "v0.30.19";
 }


### PR DESCRIPTION
Version cycle for the trait-bridge contract fixes merged in #169 (fixes #165, #166, #167, #168). Rolls the [Unreleased] changelog entries into 0.30.19 and bumps Cargo.toml / alef.toml / ALEF_REV via task set-version.