### PR TITLE
fix(pyo3): from-native converters honor the dataclass field filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **pyo3**: the generated `options._from_native_*` converters now use the same
+  field filter as the dataclass emission — binding-excluded fields no longer
+  appear as constructor kwargs (which failed at runtime and under mypy for
+  configs with excluded fields).
+
 ## [0.30.19] - 2026-07-04
 
 ### Fixed

--- a/src/backends/pyo3/gen_bindings/types.rs
+++ b/src/backends/pyo3/gen_bindings/types.rs
@@ -541,9 +541,9 @@ fn gen_from_native_converters(api: &ApiSurface, reexported_types: &[String]) -> 
     emitted.sort_by(|a, b| a.name.cmp(&b.name));
 
     for typ in emitted {
-        let fields: Vec<minijinja::Value> = typ
-            .fields
-            .iter()
+        // Same field filter as the dataclass emission above: a binding-excluded
+        // field is not a dataclass field, so it must not become a converter kwarg.
+        let fields: Vec<minijinja::Value> = binding_fields(&typ.fields)
             .map(|f| {
                 let safe_name = crate::core::keywords::python_ident(&f.name);
                 let src = format!("native.{safe_name}");

--- a/tests/backends_pyo3_gen_bindings/options_exports.rs
+++ b/tests/backends_pyo3_gen_bindings/options_exports.rs
@@ -722,3 +722,51 @@ fn test_from_native_converter_guards_optional_flag_fields() {
         "optional-flag nested fields must be None-guarded:\n{content}"
     );
 }
+
+#[test]
+fn test_from_native_converter_skips_binding_excluded_fields() {
+    // The converter must use the same field filter as the dataclass emission:
+    // a binding-excluded field is not a dataclass field, so passing it as a
+    // kwarg would fail at runtime (and under mypy).
+    let backend = Pyo3Backend;
+
+    let mut hidden = make_field("dispatch", TypeRef::String, true);
+    hidden.binding_excluded = true;
+    let config_ty = TypeDef {
+        name: "CrawlConfig".to_string(),
+        rust_path: "my_lib::CrawlConfig".to_string(),
+        has_serde: true,
+        has_default: true,
+        fields: vec![
+            make_field("depth", TypeRef::Primitive(PrimitiveType::U32), false),
+            hidden,
+        ],
+        ..Default::default()
+    };
+
+    let api = ApiSurface {
+        crate_name: "my-lib".to_string(),
+        version: "1.0.0".to_string(),
+        types: vec![config_ty],
+        ..Default::default()
+    };
+    let config = make_config();
+
+    let files = backend
+        .generate_public_api(&api, &config)
+        .expect("generate_public_api failed");
+    let options = files
+        .iter()
+        .find(|f| f.path.to_string_lossy().ends_with("options.py"))
+        .expect("options.py should be generated");
+    let content = &options.content;
+
+    assert!(
+        content.contains("depth=native.depth,"),
+        "included fields must convert:\n{content}"
+    );
+    assert!(
+        !content.contains("dispatch=native.dispatch"),
+        "binding-excluded fields must not appear in the converter:\n{content}"
+    );
+}


### PR DESCRIPTION
Fixes a gap in the #169 options converters, caught by a strict-mypy sweep of a consumer wheel.

## Problem

The generated `options._from_native_*` converters iterated the raw IR field list, while the dataclass emission filters through `binding_fields`. A config with binding-excluded fields (e.g. via `exclude_fields`) got converter kwargs for fields the dataclass doesn't declare — a runtime `TypeError` and a mypy `call-arg` error for every such config.

## Fix

The converter emission now uses the same `binding_fields` filter as the dataclass emission, with a regression test pinning that an excluded field never appears as a converter kwarg.