### PR TITLE
fix(pyo3): qualify builtins shadowed by class members in generated Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **pyo3**: annotations inside a class whose member shadows a builtin type name
+  (e.g. an `ExtractInput.bytes` field) are now qualified as `builtins.<name>`
+  in both the `.pyi` stub and the `options.py` dataclass/TypedDict emission,
+  with a conditional `import builtins` — previously `mypy --strict` rejected
+  every such annotation with `Variable "X.bytes" is not valid as a type` (#174).
+
 ## [0.32.0] - 2026-07-04
 
 ### Added

--- a/src/backends/pyo3/gen_bindings/types.rs
+++ b/src/backends/pyo3/gen_bindings/types.rs
@@ -391,6 +391,7 @@ pub(super) fn gen_options_py(
             continue;
         }
 
+        let class_start = out.len();
         if use_typeddict {
             out.push_str(&gen_typeddict(
                 typ,
@@ -520,6 +521,19 @@ pub(super) fn gen_options_py(
             }
             out.push('\n');
         }
+
+        // A field named after a builtin type shadows that builtin for the whole
+        // class body (dataclass or TypedDict alike); qualify such annotations as
+        // `builtins.<name>`. The module header adds `import builtins` when any
+        // class needed the rewrite.
+        let member_names: std::collections::HashSet<&str> =
+            binding_fields(&typ.fields).map(|f| f.name.as_str()).collect();
+        if let Some(qualified) =
+            crate::core::keywords::qualify_shadowed_python_builtins(&out[class_start..], &member_names)
+        {
+            out.truncate(class_start);
+            out.push_str(&qualified);
+        }
     }
 
     // Data enums are imported from the native module and referenced by their class name in the
@@ -530,6 +544,21 @@ pub(super) fn gen_options_py(
     // same type the package publicly exports (the options dataclass), not the
     // private native class.
     out.push_str(&gen_from_native_converters(api, reexported_types));
+
+    // Emitted when a class member shadows a builtin type name and annotations were
+    // qualified as `builtins.<name>` (see the per-class post-pass above). Inserted
+    // before the from-imports to keep the stdlib-import group isort-clean.
+    if out.contains("builtins.") {
+        out = out.replacen(
+            "from dataclasses import dataclass, field
+",
+            "import builtins
+
+from dataclasses import dataclass, field
+",
+            1,
+        );
+    }
 
     out
 }

--- a/src/backends/pyo3/gen_stubs.rs
+++ b/src/backends/pyo3/gen_stubs.rs
@@ -424,6 +424,12 @@ pub fn gen_stubs(
         lines.push("from . import options".to_string());
         lines.push("".to_string());
     }
+    // Emitted when a class member shadows a builtin type name and annotations
+    // were qualified as `builtins.<name>` (see gen_type_stub).
+    if body_joined.contains("builtins.") {
+        lines.push("import builtins".to_string());
+        lines.push("".to_string());
+    }
     if !used_typing.is_empty() {
         lines.push(format!("from typing import {}", used_typing.join(", ")));
         lines.push("".to_string());

--- a/src/backends/pyo3/gen_stubs/classes.rs
+++ b/src/backends/pyo3/gen_stubs/classes.rs
@@ -174,7 +174,19 @@ pub(super) fn gen_type_stub(
         }
     }
 
-    lines.join("\n")
+    let block = lines.join("\n");
+    // A member named after a builtin type (`bytes`, `str`, …) shadows that
+    // builtin for every annotation in this class body; qualify such usages as
+    // `builtins.<name>` so the stub survives `mypy --strict`. The stub-level
+    // import logic adds `import builtins` when this rewrites anything.
+    let member_names: std::collections::HashSet<&str> = binding_fields(&typ.fields)
+        .map(|f| f.name.as_str())
+        .chain(typ.methods.iter().map(|m| m.name.as_str()))
+        .collect();
+    match crate::core::keywords::qualify_shadowed_python_builtins(&block, &member_names) {
+        Some(qualified) => qualified,
+        None => block,
+    }
 }
 
 /// Generate __init__ signature stub for a struct.

--- a/src/core/keywords.rs
+++ b/src/core/keywords.rs
@@ -892,5 +892,146 @@ pub fn zig_ident(name: &str) -> String {
     zig_safe_name(&sanitized).unwrap_or(sanitized)
 }
 
+/// Python builtin names that are usable in type positions. A class member
+/// (field or method) with one of these names shadows the builtin for every
+/// annotation in that class body — `mypy --strict` rejects the annotation with
+/// `Variable "..." is not valid as a type`. Annotations in such a class must
+/// qualify the builtin as `builtins.<name>`.
+pub const PYTHON_BUILTIN_TYPE_NAMES: &[&str] = &[
+    "bool",
+    "bytearray",
+    "bytes",
+    "complex",
+    "dict",
+    "float",
+    "frozenset",
+    "int",
+    "list",
+    "memoryview",
+    "object",
+    "set",
+    "str",
+    "tuple",
+    "type",
+];
+
+/// Qualify builtin type names shadowed by `member_names` inside one Python
+/// class body (or type-hint string), rewriting type-position occurrences to
+/// `builtins.<name>`. Returns `None` when nothing needed rewriting.
+///
+/// Occurrences are left alone when they are:
+/// - inside string literals (including triple-quoted docstrings) or comments,
+/// - attribute accesses (preceded by `.`),
+/// - the declaration name itself — a field (`bytes: ...`), parameter
+///   (`(bytes: ...`), or method (`def bytes(`) — recognized as an identifier
+///   followed by `:` whose preceding context is a declaration position
+///   (line start, `(`, `,`, or `*`). Return-type positions (`-> bytes:`) are
+///   still qualified.
+pub fn qualify_shadowed_python_builtins(block: &str, member_names: &std::collections::HashSet<&str>) -> Option<String> {
+    let shadowed: std::collections::HashSet<&str> = PYTHON_BUILTIN_TYPE_NAMES
+        .iter()
+        .copied()
+        .filter(|b| member_names.contains(b))
+        .collect();
+    if shadowed.is_empty() {
+        return None;
+    }
+
+    const TRIPLE_DOUBLE: &str = "\"\"\"";
+    const TRIPLE_SINGLE: &str = "'''";
+
+    let mut out = String::with_capacity(block.len() + 64);
+    let mut changed = false;
+    // Cross-line string state: Some(delim) while inside a (possibly triple) quote.
+    let mut string_delim: Option<&'static str> = None;
+
+    for line in block.split_inclusive('\n') {
+        let line_bytes = line.as_bytes();
+        let mut i = 0;
+        while i < line_bytes.len() {
+            // Inside a string literal: scan for its closing delimiter.
+            if let Some(delim) = string_delim {
+                if line[i..].starts_with(delim) {
+                    out.push_str(delim);
+                    i += delim.len();
+                    string_delim = None;
+                } else {
+                    out.push(line_bytes[i] as char);
+                    i += 1;
+                }
+                continue;
+            }
+            let ch = line_bytes[i] as char;
+            // Comment: copy the rest of the line verbatim.
+            if ch == '#' {
+                out.push_str(&line[i..]);
+                break;
+            }
+            // String start (triple quotes before singles).
+            if line[i..].starts_with(TRIPLE_DOUBLE) || line[i..].starts_with(TRIPLE_SINGLE) {
+                let delim = if line_bytes[i] == b'"' {
+                    TRIPLE_DOUBLE
+                } else {
+                    TRIPLE_SINGLE
+                };
+                out.push_str(delim);
+                i += 3;
+                string_delim = Some(delim);
+                continue;
+            }
+            if ch == '"' || ch == '\'' {
+                let delim = if ch == '"' { "\"" } else { "'" };
+                out.push(ch);
+                i += 1;
+                string_delim = Some(delim);
+                continue;
+            }
+            // Identifier token.
+            if ch.is_ascii_alphabetic() || ch == '_' {
+                let start = i;
+                while i < line_bytes.len() && ((line_bytes[i] as char).is_ascii_alphanumeric() || line_bytes[i] == b'_')
+                {
+                    i += 1;
+                }
+                let ident = &line[start..i];
+                let is_attribute = line[..start].ends_with('.');
+                if !is_attribute && shadowed.contains(ident) && !is_declaration_name(line, start, i) {
+                    out.push_str("builtins.");
+                    out.push_str(ident);
+                    changed = true;
+                } else {
+                    out.push_str(ident);
+                }
+                continue;
+            }
+            out.push(ch);
+            i += 1;
+        }
+        // Single-quoted strings do not continue across lines in generated code.
+        if let Some(delim) = string_delim {
+            if delim.len() == 1 {
+                string_delim = None;
+            }
+        }
+    }
+
+    changed.then_some(out)
+}
+
+/// True when the identifier at `line[start..end]` is a declaration NAME rather
+/// than a type usage: followed by `:` and preceded by a declaration position
+/// (line start, `(`, `,`, or `*`), or preceded by `def `.
+fn is_declaration_name(line: &str, start: usize, end: usize) -> bool {
+    let before = line[..start].trim_end();
+    if before.ends_with("def") {
+        return true;
+    }
+    let followed_by_colon = line[end..].trim_start().starts_with(':');
+    if !followed_by_colon {
+        return false;
+    }
+    before.is_empty() || before.ends_with('(') || before.ends_with(',') || before.ends_with('*')
+}
+
 #[cfg(test)]
 mod tests;

--- a/tests/backends_pyo3_gen_bindings/options_exports.rs
+++ b/tests/backends_pyo3_gen_bindings/options_exports.rs
@@ -722,3 +722,51 @@ fn test_from_native_converter_guards_optional_flag_fields() {
         "optional-flag nested fields must be None-guarded:\n{content}"
     );
 }
+
+#[test]
+fn test_options_dataclass_qualifies_builtins_shadowed_by_field_names() {
+    // Same shadowing rule as the stub: a dataclass field named `bytes` shadows
+    // the builtin for the class body, so its annotation must be qualified.
+    let backend = Pyo3Backend;
+
+    let input_ty = TypeDef {
+        name: "ExtractInput".to_string(),
+        rust_path: "my_lib::ExtractInput".to_string(),
+        has_serde: true,
+        has_default: true,
+        fields: vec![
+            make_field("bytes", TypeRef::Optional(Box::new(TypeRef::Bytes)), true),
+            make_field("uri", TypeRef::Optional(Box::new(TypeRef::String)), true),
+        ],
+        ..Default::default()
+    };
+    let api = ApiSurface {
+        crate_name: "my-lib".to_string(),
+        version: "1.0.0".to_string(),
+        types: vec![input_ty],
+        ..Default::default()
+    };
+    let config = make_config();
+
+    let files = backend
+        .generate_public_api(&api, &config)
+        .expect("generate_public_api failed");
+    let options = files
+        .iter()
+        .find(|f| f.path.to_string_lossy().ends_with("options.py"))
+        .expect("options.py should be generated");
+    let content = &options.content;
+
+    assert!(
+        content.contains("bytes: builtins.bytes | None"),
+        "shadowed builtin must be qualified in the dataclass annotation:\n{content}"
+    );
+    assert!(
+        content.contains("import builtins"),
+        "options.py must import builtins when qualification happened:\n{content}"
+    );
+    assert!(
+        content.contains("uri: str | None"),
+        "non-shadowed builtins stay plain:\n{content}"
+    );
+}

--- a/tests/backends_pyo3_gen_stubs_test.rs
+++ b/tests/backends_pyo3_gen_stubs_test.rs
@@ -2301,3 +2301,58 @@ fn test_pyi_plugin_protocol_types_config_params_as_options_dataclass() {
         "plugin Protocol must type options-dataclass config params as options.X:\n{content}"
     );
 }
+
+#[test]
+fn test_pyi_qualifies_builtins_shadowed_by_field_names() {
+    // A field named `bytes` shadows the builtin type for every annotation in
+    // that class body (mypy --strict: "not valid as a type"), so annotations
+    // there must qualify the builtin as `builtins.bytes`. Classes without the
+    // shadowing keep plain builtins, and the stub imports `builtins` only when
+    // qualification happened.
+    let backend = Pyo3Backend;
+    let config = make_config_with_stubs();
+
+    let shadowing = TypeDef {
+        name: "ExtractInput".to_string(),
+        rust_path: "test_lib::ExtractInput".to_string(),
+        has_serde: true,
+        fields: vec![
+            make_field("bytes", TypeRef::Optional(Box::new(TypeRef::Bytes)), true),
+            make_field("mime", TypeRef::Optional(Box::new(TypeRef::String)), true),
+        ],
+        ..Default::default()
+    };
+    let plain = TypeDef {
+        name: "Payload".to_string(),
+        rust_path: "test_lib::Payload".to_string(),
+        has_serde: true,
+        fields: vec![make_field("data", TypeRef::Bytes, false)],
+        ..Default::default()
+    };
+
+    let api = ApiSurface {
+        crate_name: "test_lib".to_string(),
+        version: "0.1.0".to_string(),
+        types: vec![shadowing, plain],
+        ..Default::default()
+    };
+
+    let content = backend.generate_type_stubs(&api, &config).unwrap()[0].content.clone();
+
+    assert!(
+        content.contains("bytes: builtins.bytes | None"),
+        "shadowed builtin must be qualified in the field annotation:\n{content}"
+    );
+    assert!(
+        content.contains("import builtins"),
+        "stub must import builtins when qualification happened:\n{content}"
+    );
+    assert!(
+        content.contains("data: bytes"),
+        "classes without shadowing keep the plain builtin:\n{content}"
+    );
+    assert!(
+        !content.contains("builtins.bytes: "),
+        "the member declaration name itself must not be qualified:\n{content}"
+    );
+}


### PR DESCRIPTION
Fixes #174.

## Problem

A class member named after a builtin type shadows that builtin for every annotation in the class body — `ExtractInput` declares `bytes: bytes | None`, and `mypy --strict` rejects each such annotation with `Variable "ExtractInput.bytes" is not valid as a type`. Both generated Python surfaces are exposed: the `.pyi` stub and the `options.py` dataclass/TypedDict emission.

## Fix

A central, quote- and comment-aware rewriter in `core::keywords` (`qualify_shadowed_python_builtins` + `PYTHON_BUILTIN_TYPE_NAMES`) qualifies type-position occurrences of a shadowed builtin as `builtins.<name>`, leaving declaration names (`bytes: ...`, params, `def bytes(`) and string/comment content untouched while still catching return-type positions (`-> bytes:`). Applied per class in the stub emission and the options dataclass/TypedDict emission; `import builtins` is emitted only when a rewrite happened.

## Verification

Regression tests pin: qualified field annotation + conditional import in the stub, the same for options.py dataclasses, unshadowed classes keeping plain builtins, and declaration names staying unqualified.