### PR TITLE
fix(trait-bridge): stop sync infallible shims from swallowing host failures; go/dart crash guards; java direct-value ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the ffi null-slot/null-result edge defaults.
 - **go**: generated cgo trampolines recover host panics instead of crashing
   the process, logging to stderr and returning the zero value (fallible slots
-  marshal the panic text through `outError`). The invalid-handle path no
-  longer fabricates `1` as a return value.
+  marshal the panic text through `outError`). The invalid-handle paths —
+  including the four plugin lifecycle slots — log and marshal `outError`
+  instead of fabricating `1` as a return value.
 - **dart**: the block_on shim logs and returns the default when an infallible
   host callback panics, instead of aborting the calling thread via `expect`.
-- **java**: sync infallible primitive/unit-returning trait methods now use the
-  vtable's direct-value convention. The previous JSON-convention upcall stubs
-  mismatched the C slot signature — a wild pointer write plus the status code
-  read back as the return value — breaking such methods on every call.
+- **java**: sync infallible trait methods now match the vtable slot signature
+  exactly. Primitive/unit returns use the direct-value convention (the previous
+  JSON-convention upcall stubs mismatched the C slot — a wild pointer write
+  plus the status code read back as the return value — breaking such methods on
+  every call); infallible `Char`/`Path` slots no longer declare a phantom
+  `outError`, and infallible `Optional<non-primitive>`/`Bytes` slots declare no
+  out-pointers at all, mirroring `c_return_convention`.
 
 ## [0.32.2] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **pyo3**: sync trait-bridge shims for infallible methods no longer swallow
+  host exceptions silently. A raised Python callback is logged to stderr with
+  the wrapper and method name before the default value is substituted
+  (value-returning methods) or the call is discarded (unit methods), so a
+  fabricated default — e.g. a zero token count that reads as "fits any
+  budget" — is no longer indistinguishable from a real result.
+
 ## [0.32.2] - 2026-07-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **pyo3**: sync trait-bridge shims for infallible methods no longer swallow
-  host exceptions silently. A raised Python callback is logged to stderr with
-  the wrapper and method name before the default value is substituted
-  (value-returning methods) or the call is discarded (unit methods), so a
-  fabricated default — e.g. a zero token count that reads as "fits any
-  budget" — is no longer indistinguishable from a real result.
+- **trait-bridge**: sync infallible bridge methods no longer swallow host
+  failures silently. A raised/thrown host callback is logged with the wrapper
+  and method name before the default value is substituted (value-returning
+  methods) or the call is discarded (unit methods), so a fabricated default —
+  e.g. a zero token count that reads as "fits any budget" — is no longer
+  indistinguishable from a real result. Covers pyo3, napi, magnus, php, wasm
+  (console.error), jni (including the host-error envelope text the dispatcher
+  already marshals), rustler, extendr, the csharp primitive-return adapter,
+  and the ffi null-slot/null-result edge defaults.
+- **go**: generated cgo trampolines recover host panics instead of crashing
+  the process, logging to stderr and returning the zero value (fallible slots
+  marshal the panic text through `outError`). The invalid-handle path no
+  longer fabricates `1` as a return value.
+- **dart**: the block_on shim logs and returns the default when an infallible
+  host callback panics, instead of aborting the calling thread via `expect`.
+- **java**: sync infallible primitive/unit-returning trait methods now use the
+  vtable's direct-value convention. The previous JSON-convention upcall stubs
+  mismatched the C slot signature — a wild pointer write plus the status code
+  read back as the return value — breaking such methods on every call.
 
 ## [0.32.2] - 2026-07-04
 

--- a/src/backends/csharp/trait_bridge.rs
+++ b/src/backends/csharp/trait_bridge.rs
@@ -809,7 +809,9 @@ fn gen_single_trait_bridge(
         }
 
         if is_primitive_return {
-            callbacks.push_str("        } catch (Exception) {\n");
+            // Bind ex so the swallowed host failure is logged before the
+            // default is substituted (the direct-value slot has no outError).
+            callbacks.push_str("        } catch (Exception ex) {\n");
         } else if !is_options_field {
             // Only bind ex for non-primitive, non-options-field returns where we log it
             callbacks.push_str("        } catch (Exception ex) {\n");
@@ -850,6 +852,12 @@ fn gen_single_trait_bridge(
         if !is_primitive_return {
             callbacks.push_str("            return 1;\n");
         } else {
+            // Direct-value slot: a thrown exception cannot propagate, so log it
+            // before returning the default — a silent default is
+            // indistinguishable from a real result to the caller.
+            callbacks.push_str(&format!(
+                "            Console.Error.WriteLine($\"[{trait_pascal}Bridge] host '{method_pascal}' threw; returning default: {{ex}}\");\n"
+            ));
             callbacks.push_str("            return 0;\n");
         }
         callbacks.push_str("        } finally {\n");

--- a/src/backends/dart/gen_rust_crate/trait_bridge/emit.rs
+++ b/src/backends/dart/gen_rust_crate/trait_bridge/emit.rs
@@ -216,6 +216,7 @@ pub(crate) fn emit_trait_bridge(
         emit_trait_bridge_method(
             out,
             method,
+            callbacks_struct_name.as_str(),
             source_crate_name,
             type_paths,
             &api.excluded_type_paths,

--- a/src/backends/dart/gen_rust_crate/trait_bridge/methods.rs
+++ b/src/backends/dart/gen_rust_crate/trait_bridge/methods.rs
@@ -18,6 +18,7 @@ use crate::backends::dart::gen_rust_crate::trait_types::{
 pub(super) fn emit_trait_bridge_method(
     out: &mut String,
     method: &MethodDef,
+    bridge_name: &str,
     source_crate_name: &str,
     type_paths: &std::collections::HashMap<String, String>,
     excluded_type_paths: &std::collections::HashMap<String, String>,
@@ -198,6 +199,9 @@ pub(super) fn emit_trait_bridge_method(
                 minijinja::context! {
                     call_expr => call_expr.as_str(),
                     result_var => "__ret_bridge",
+                    has_error => method.error_type.is_some(),
+                    wrapper => bridge_name,
+                    method_name => method_name.as_str(),
                 },
             ));
             if method.error_type.is_some() {
@@ -265,6 +269,9 @@ pub(super) fn emit_trait_bridge_method(
                 minijinja::context! {
                     call_expr => call_expr.as_str(),
                     result_var => "__result",
+                    has_error => true,
+                    wrapper => bridge_name,
+                    method_name => method_name.as_str(),
                 },
             ));
             if named_return_default {
@@ -321,6 +328,9 @@ pub(super) fn emit_trait_bridge_method(
             minijinja::context! {
                 call_expr => call_expr.as_str(),
                 result_var => "__result",
+                has_error => false,
+                wrapper => bridge_name,
+                method_name => method_name.as_str(),
             },
         ));
         if named_return_default {

--- a/src/backends/dart/gen_rust_crate/trait_bridge/methods.rs
+++ b/src/backends/dart/gen_rust_crate/trait_bridge/methods.rs
@@ -200,6 +200,9 @@ pub(super) fn emit_trait_bridge_method(
                     call_expr => call_expr.as_str(),
                     result_var => "__ret_bridge",
                     has_error => method.error_type.is_some(),
+                    // Excluded core return types have no Default guarantee —
+                    // log the panic, then re-raise instead of substituting.
+                    resume_panic => true,
                     wrapper => bridge_name,
                     method_name => method_name.as_str(),
                 },

--- a/src/backends/dart/gen_rust_crate/trait_bridge/tests.rs
+++ b/src/backends/dart/gen_rust_crate/trait_bridge/tests.rs
@@ -120,6 +120,7 @@ fn excluded_named_result_return_deserializes_with_error_mapping() {
     emit_trait_bridge_method(
         &mut out,
         &method,
+        "DemoBridge",
         "demo",
         &type_paths,
         &excluded_type_paths,
@@ -173,6 +174,7 @@ fn excluded_named_result_param_serializes_with_error_mapping() {
     emit_trait_bridge_method(
         &mut out,
         &method,
+        "DemoBridge",
         "demo",
         &type_paths,
         &excluded_type_paths,

--- a/src/backends/dart/templates/rust_trait_method_block_on.jinja
+++ b/src/backends/dart/templates/rust_trait_method_block_on.jinja
@@ -1,7 +1,31 @@
         let __fut = {{ call_expr }};
+{% if has_error %}
         let {{ result_var }} = std::thread::spawn(move || {
             ::tokio::runtime::Builder::new_current_thread()
                 .build()
                 .expect("build alef visitor tokio runtime")
                 .block_on(__fut)
         }).join().expect("thread panicked");
+{% else %}
+        let {{ result_var }} = match std::thread::spawn(move || {
+            ::tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("build alef visitor tokio runtime")
+                .block_on(__fut)
+        }).join() {
+            Ok(v) => v,
+            Err(e) => {
+                // This method's Rust signature is infallible, so a panic on the
+                // callback thread cannot propagate. Log before substituting the
+                // default — a silent default is indistinguishable from a real
+                // result to the caller.
+                let msg = e
+                    .downcast_ref::<&str>()
+                    .map(|s| (*s).to_string())
+                    .or_else(|| e.downcast_ref::<String>().cloned())
+                    .unwrap_or_else(|| "non-string panic payload".to_string());
+                eprintln!("[{{ wrapper }}] host '{{ method_name }}' panicked; returning default: {msg}");
+                return Default::default();
+            }
+        };
+{% endif %}

--- a/src/backends/dart/templates/rust_trait_method_block_on.jinja
+++ b/src/backends/dart/templates/rust_trait_method_block_on.jinja
@@ -15,17 +15,26 @@
         }).join() {
             Ok(v) => v,
             Err(e) => {
-                // This method's Rust signature is infallible, so a panic on the
-                // callback thread cannot propagate. Log before substituting the
-                // default — a silent default is indistinguishable from a real
-                // result to the caller.
                 let msg = e
                     .downcast_ref::<&str>()
                     .map(|s| (*s).to_string())
                     .or_else(|| e.downcast_ref::<String>().cloned())
                     .unwrap_or_else(|| "non-string panic payload".to_string());
+{% if resume_panic %}
+                // Excluded core return types carry no Default guarantee, so a
+                // substituted value is not an option here — log the failure,
+                // then re-raise the original panic (previous behavior, now
+                // observable).
+                eprintln!("[{{ wrapper }}] host '{{ method_name }}' panicked: {msg}");
+                std::panic::resume_unwind(e);
+{% else %}
+                // This method's Rust signature is infallible, so a panic on the
+                // callback thread cannot propagate. Log before substituting the
+                // default — a silent default is indistinguishable from a real
+                // result to the caller.
                 eprintln!("[{{ wrapper }}] host '{{ method_name }}' panicked; returning default: {msg}");
                 return Default::default();
+{% endif %}
             }
         };
 {% endif %}

--- a/src/backends/extendr/templates/sync_method_complex_return.jinja
+++ b/src/backends/extendr/templates/sync_method_complex_return.jinja
@@ -18,29 +18,40 @@ let result = fn_robj.call(args);
 {% if is_primitive_return %}
 // Primitive return: extract directly from Robj without JSON deserialization
 match result {
-    Err(_) => {
 {% if has_error %}
+    Err(_) => {
         Err({{ failed_method_error }})
-{% else %}
-        Default::default()
-{% endif %}
     }
+{% else %}
+    // This method's Rust signature is infallible, so an R error cannot
+    // propagate. Log before substituting the default — a silent default is
+    // indistinguishable from a real result to the caller.
+    Err(e) => {
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' raised; returning default: {e}");
+        Default::default()
+    }
+{% endif %}
     Ok(val) => {
 {% if return_type == "bool" %}
-        let int_val = val.as_integer()
+        let extracted = val.as_integer()
             .map(|i| i != 0)
-            .or_else(|| val.as_real().map(|r| r != 0.0))
-            .unwrap_or(false);
+            .or_else(|| val.as_real().map(|r| r != 0.0));
 {% else %}
-        let int_val = val.as_integer()
+        let extracted = val.as_integer()
             .map(|i| i as {{ return_type }})
-            .or_else(|| val.as_real().map(|r| r as {{ return_type }}))
-            .unwrap_or_default();
+            .or_else(|| val.as_real().map(|r| r as {{ return_type }}));
 {% endif %}
 {% if has_error %}
+        let int_val = extracted.unwrap_or_default();
         Ok(int_val)
 {% else %}
-        int_val
+        match extracted {
+            Some(v) => v,
+            None => {
+                eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned a non-numeric value; returning default");
+                Default::default()
+            }
+        }
 {% endif %}
     }
 }
@@ -50,13 +61,19 @@ match result {
 // `serde::Serialize`, so we cannot serialize it directly — the caller must serialize on
 // the R side.
 match result {
-    Err(_) => {
 {% if has_error %}
+    Err(_) => {
         Err({{ failed_method_error }})
-{% else %}
-        Default::default()
-{% endif %}
     }
+{% else %}
+    // This method's Rust signature is infallible, so an R error cannot
+    // propagate. Log before substituting the default — a silent default is
+    // indistinguishable from a real result to the caller.
+    Err(e) => {
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' raised; returning default: {e}");
+        Default::default()
+    }
+{% endif %}
     Ok(val) => {
 {%- if native_return_binding %}
         // Native-object return: unwrap the host's native `ExternalPtr` and convert via
@@ -77,7 +94,10 @@ match result {
             Err(_) => Err({{ deserialization_error }}),
 {% else %}
             Ok(parsed) => parsed,
-            Err(_) => Default::default(),
+            Err(e) => {
+                eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned an unparseable value; returning default: {e}");
+                Default::default()
+            }
 {% endif %}
         }
     }

--- a/src/backends/extendr/templates/sync_method_non_unit_return.jinja
+++ b/src/backends/extendr/templates/sync_method_non_unit_return.jinja
@@ -31,7 +31,13 @@ match result {
 }
 {% else %}
 match result {
-    Err(_) => Default::default(),
+    // This method's Rust signature is infallible, so an R error cannot
+    // propagate. Log before substituting the default — a silent default is
+    // indistinguishable from a real result to the caller.
+    Err(e) => {
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' raised; returning default: {e}");
+        Default::default()
+    }
     Ok(val) => {
         let s = val.as_string().ok().and_then(|mut v| {
             if v.is_empty() { None } else { Some(v.remove(0)) }
@@ -39,7 +45,10 @@ match result {
 
         match s.as_str() {
             "" | "null" => Default::default(),
-            _ => serde_json::from_str::<_>(&s).unwrap_or_default()
+            _ => serde_json::from_str::<_>(&s).unwrap_or_else(|e| {
+                eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned an unparseable value; returning default: {e}");
+                Default::default()
+            })
         }
     }
 }

--- a/src/backends/extendr/templates/sync_method_string_return.jinja
+++ b/src/backends/extendr/templates/sync_method_string_return.jinja
@@ -16,13 +16,19 @@ let result = fn_robj.call(args);
 {% endif %}
 
 match result {
-    Err(_) => {
 {% if has_error %}
+    Err(_) => {
         Err({{ failed_method_error }})
-{% else %}
-        Default::default()
-{% endif %}
     }
+{% else %}
+    // This method's Rust signature is infallible, so an R error cannot
+    // propagate. Log before substituting the default — a silent default is
+    // indistinguishable from a real result to the caller.
+    Err(e) => {
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' raised; returning default: {e}");
+        Default::default()
+    }
+{% endif %}
     Ok(val) => {
         if let Some(s) = val.as_str() {
             {% if has_error %}Ok(s.to_string()){% else %}s.to_string(){% endif %}
@@ -30,6 +36,7 @@ match result {
 {% if has_error %}
             Err({{ invalid_type_error }})
 {% else %}
+            eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned a non-string value; returning default");
             Default::default()
 {% endif %}
         }

--- a/src/backends/extendr/templates/sync_method_unit_return.jinja
+++ b/src/backends/extendr/templates/sync_method_unit_return.jinja
@@ -15,13 +15,20 @@ let args = extendr_api::Pairlist::from_pairs(&[{{ args_pairs }}]);
 let result = fn_robj.call(args);
 {% endif %}
 
+{% if has_error %}
 match result {
     Err(_) if {{ has_error_check }} => {
-{% if has_error %}
         Err({{ failed_method_error }})
-{% else %}
-        Ok(())
-{% endif %}
     }
-    _ => {% if has_error %}Ok(()){% else %}(){% endif %},
+    _ => Ok(()),
 }
+{% else %}
+match result {
+    // Infallible unit method: an R error cannot propagate — log it before
+    // discarding so a failed callback is not invisible to the caller.
+    Err(e) => {
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' raised; ignoring: {e}");
+    }
+    _ => (),
+}
+{% endif %}

--- a/src/backends/extendr/trait_bridge.rs
+++ b/src/backends/extendr/trait_bridge.rs
@@ -164,6 +164,7 @@ impl TraitBridgeGenerator for ExtendrBridgeGenerator {
         crate::backends::extendr::template_env::render(
             template_name,
             minijinja::context! {
+                wrapper => spec.wrapper_name(),
                 method_name => name,
                 has_error => has_error,
                 has_error_check => if has_error { "true" } else { "false" },

--- a/src/backends/ffi/templates/ffi_decode_string_value.jinja
+++ b/src/backends/ffi/templates/ffi_decode_string_value.jinja
@@ -1,4 +1,5 @@
 if _out_result.is_null() {
+    eprintln!("[{{ wrapper }}] host '{{ method_name }}' wrote no result; returning default");
     return String::new();
 }
 // SAFETY: out_result was written by the callee as a valid NUL-terminated string.

--- a/src/backends/ffi/templates/ffi_return_default_4.jinja
+++ b/src/backends/ffi/templates/ffi_return_default_4.jinja
@@ -1,1 +1,2 @@
+    eprintln!("[{{ wrapper }}] vtable slot for host '{{ method_name }}' is not initialised; returning default");
     return {{ default_expr }};

--- a/src/backends/ffi/templates/ffi_serde_from_str_default.jinja
+++ b/src/backends/ffi/templates/ffi_serde_from_str_default.jinja
@@ -1,1 +1,4 @@
-serde_json::from_str::<{{ ret_ty }}>(&json).unwrap_or_default()
+serde_json::from_str::<{{ ret_ty }}>(&json).unwrap_or_else(|e| {
+    eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned an unparseable value; returning default: {e}");
+    Default::default()
+})

--- a/src/backends/ffi/trait_bridge/call_body.rs
+++ b/src/backends/ffi/trait_bridge/call_body.rs
@@ -77,11 +77,14 @@ impl FfiBridgeGenerator {
             );
             out.push_str(&make_err(null_msg));
         } else {
-            // For infallible methods, return the Rust default value
+            // For infallible methods, log the uninitialised slot (the failure
+            // cannot propagate) and return the Rust default value.
             let default_expr = default_for_type(&method.return_type);
             out.push_str(&crate::backends::ffi::template_env::render(
                 "ffi_return_default_4.jinja",
                 minijinja::context! {
+                    wrapper => spec.wrapper_name(),
+                    method_name => name,
                     default_expr => &default_expr,
                 },
             ));
@@ -459,7 +462,11 @@ impl FfiBridgeGenerator {
                 TypeRef::String | TypeRef::Char | TypeRef::Path => {
                     out.push_str(&crate::backends::ffi::template_env::render(
                         "ffi_decode_string_value.jinja",
-                        minijinja::context! { vtable_expr => "self.vtable" },
+                        minijinja::context! {
+                            wrapper => spec.wrapper_name(),
+                            method_name => name,
+                            vtable_expr => "self.vtable",
+                        },
                     ));
                 }
                 TypeRef::Named(_) | TypeRef::Json | TypeRef::Vec(_) | TypeRef::Map(_, _) => {
@@ -468,6 +475,11 @@ impl FfiBridgeGenerator {
                         "if _out_result.is_null() {
 ",
                     );
+                    out.push_str(&format!(
+                        "    eprintln!(\"[{wrapper}] host '{name}' wrote no result; returning default\");
+",
+                        wrapper = spec.wrapper_name(),
+                    ));
                     out.push_str(
                         "    return Default::default();
 ",
@@ -487,6 +499,8 @@ impl FfiBridgeGenerator {
                     out.push_str(&crate::backends::ffi::template_env::render(
                         "ffi_serde_from_str_default.jinja",
                         minijinja::context! {
+                            wrapper => spec.wrapper_name(),
+                            method_name => name,
                             ret_ty => &ret_ty,
                         },
                     ));

--- a/src/backends/go/templates/plugin_method_trampoline_header.jinja
+++ b/src/backends/go/templates/plugin_method_trampoline_header.jinja
@@ -1,1 +1,1 @@
-func go{{ pascal }}{{ method }}({{ params }}) C.int32_t {
+func go{{ pascal }}{{ method }}({{ params }}) (ret C.int32_t) {

--- a/src/backends/go/templates/trampoline_signature.jinja
+++ b/src/backends/go/templates/trampoline_signature.jinja
@@ -2,4 +2,4 @@ func {{ name }}(
 {% for param in params %}
 	{{ param }},
 {% endfor %}
-) C.{{ return_type | default(value="int32_t") }} {
+) (ret C.{{ return_type | default(value="int32_t") }}) {

--- a/src/backends/go/trait_bridge/dispatch.rs
+++ b/src/backends/go/trait_bridge/dispatch.rs
@@ -2,10 +2,38 @@ use super::helpers::{capitalize, gen_param_conversion, rust_to_c_type};
 use crate::core::ir::{MethodDef, TypeRef};
 use heck::ToPascalCase;
 
+/// Emit a deferred `recover()` guard at the top of an exported cgo callback.
+///
+/// A Go panic must not unwind across the cgo boundary into the Rust caller —
+/// that aborts the whole process. The trampoline signatures use a named return
+/// value (`ret`) so the deferred closure can substitute a result: fallible
+/// slots surface the panic through `outError` (status 1), infallible slots log
+/// to stderr and return the zero value.
+fn gen_panic_recovery(out: &mut String, trait_pascal: &str, method_pascal: &str, fallible: bool) {
+    out.push_str("\tdefer func() {\n");
+    out.push_str("\t\tif r := recover(); r != nil {\n");
+    if fallible {
+        out.push_str(&format!(
+            "\t\t\tfmt.Fprintln(os.Stderr, \"[{trait_pascal}Bridge] host '{method_pascal}' panicked:\", r)\n"
+        ));
+        out.push_str("\t\t\t*outError = C.CString(fmt.Sprint(r))\n");
+        out.push_str("\t\t\tret = 1\n");
+    } else {
+        out.push_str(&format!(
+            "\t\t\tfmt.Fprintln(os.Stderr, \"[{trait_pascal}Bridge] host '{method_pascal}' panicked; returning default:\", r)\n"
+        ));
+        out.push_str("\t\t\tret = 0\n");
+    }
+    out.push_str("\t\t}\n");
+    out.push_str("\t}()\n");
+    out.push('\n');
+}
+
 /// Generate one trampoline function (implementation without //export).
 /// The //export declaration is in binding.go to avoid duplicate definitions.
 pub(super) fn gen_trampoline(out: &mut String, trait_name: &str, trait_pascal: &str, method: &MethodDef) {
-    let export_name = format!("go{}{}", trait_pascal, method.name.to_pascal_case());
+    let method_pascal = method.name.to_pascal_case();
+    let export_name = format!("go{}{}", trait_pascal, method_pascal);
 
     let mut params = vec!["userData unsafe.Pointer".to_string()];
     for p in &method.params {
@@ -71,6 +99,9 @@ pub(super) fn gen_trampoline(out: &mut String, trait_name: &str, trait_pascal: &
     ));
     out.push('\n');
 
+    let fallible = method.error_type.is_some();
+    gen_panic_recovery(out, trait_pascal, &method_pascal, fallible);
+
     // Retrieve the Go object from the handle
     out.push_str("\thandle := cgo.Handle(uintptr(unsafe.Pointer(userData)))\n");
     out.push_str(&crate::backends::go::template_env::render(
@@ -81,7 +112,20 @@ pub(super) fn gen_trampoline(out: &mut String, trait_name: &str, trait_pascal: &
     ));
     out.push('\n');
     out.push_str("\tif !ok {\n");
-    out.push_str("\t\treturn 1  // error: invalid handle\n");
+    if fallible {
+        out.push_str(&format!(
+            "\t\tfmt.Fprintln(os.Stderr, \"[{trait_pascal}Bridge] host '{method_pascal}' called with an invalid handle\")\n"
+        ));
+        out.push_str("\t\t*outError = C.CString(\"invalid handle\")\n");
+        out.push_str("\t\treturn 1\n");
+    } else {
+        // For direct-value slots a nonzero status here would fabricate a real
+        // return value; log and return the zero value instead.
+        out.push_str(&format!(
+            "\t\tfmt.Fprintln(os.Stderr, \"[{trait_pascal}Bridge] host '{method_pascal}' called with an invalid handle; returning default\")\n"
+        ));
+        out.push_str("\t\treturn 0\n");
+    }
     out.push_str("\t}\n");
     out.push('\n');
 
@@ -150,7 +194,12 @@ pub(super) fn gen_trampoline(out: &mut String, trait_name: &str, trait_pascal: &
         }
     }
 
-    out.push_str("\treturn 0  // success\n");
+    // Simple-primitive conversions return the value directly (every path above
+    // ends in an unconditional return), so only status-slot trampolines need
+    // the trailing success return.
+    if !is_simple_primitive {
+        out.push_str("\treturn 0  // success\n");
+    }
     out.push_str("}\n");
     out.push('\n');
 }
@@ -237,6 +286,7 @@ pub(super) fn gen_plugin_trampolines(out: &mut String, trait_name: &str, trait_p
         },
     ));
     out.push('\n');
+    gen_panic_recovery(out, trait_pascal, "Name", true);
     out.push_str("\thandle := cgo.Handle(uintptr(unsafe.Pointer(userData)))\n");
     out.push_str(&crate::backends::go::template_env::render(
         "handle_type_assertion.jinja",
@@ -271,6 +321,7 @@ pub(super) fn gen_plugin_trampolines(out: &mut String, trait_name: &str, trait_p
         },
     ));
     out.push('\n');
+    gen_panic_recovery(out, trait_pascal, "Version", true);
     out.push_str("\thandle := cgo.Handle(uintptr(unsafe.Pointer(userData)))\n");
     out.push_str(&crate::backends::go::template_env::render(
         "handle_type_assertion.jinja",
@@ -305,6 +356,7 @@ pub(super) fn gen_plugin_trampolines(out: &mut String, trait_name: &str, trait_p
         },
     ));
     out.push('\n');
+    gen_panic_recovery(out, trait_pascal, "Initialize", true);
     out.push_str("\thandle := cgo.Handle(uintptr(unsafe.Pointer(userData)))\n");
     out.push_str(&crate::backends::go::template_env::render(
         "handle_type_assertion.jinja",
@@ -342,6 +394,7 @@ pub(super) fn gen_plugin_trampolines(out: &mut String, trait_name: &str, trait_p
         },
     ));
     out.push('\n');
+    gen_panic_recovery(out, trait_pascal, "Shutdown", true);
     out.push_str("\thandle := cgo.Handle(uintptr(unsafe.Pointer(userData)))\n");
     out.push_str(&crate::backends::go::template_env::render(
         "handle_type_assertion.jinja",

--- a/src/backends/go/trait_bridge/dispatch.rs
+++ b/src/backends/go/trait_bridge/dispatch.rs
@@ -296,6 +296,10 @@ pub(super) fn gen_plugin_trampolines(out: &mut String, trait_name: &str, trait_p
     ));
     out.push('\n');
     out.push_str("\tif !ok {\n");
+    out.push_str(&format!(
+        "\t\tfmt.Fprintln(os.Stderr, \"[{trait_pascal}Bridge] host 'Name' called with an invalid handle\")\n"
+    ));
+    out.push_str("\t\t*outError = C.CString(\"invalid handle\")\n");
     out.push_str("\t\treturn 1\n");
     out.push_str("\t}\n");
     out.push_str("\tname := impl.Name()\n");
@@ -331,6 +335,10 @@ pub(super) fn gen_plugin_trampolines(out: &mut String, trait_name: &str, trait_p
     ));
     out.push('\n');
     out.push_str("\tif !ok {\n");
+    out.push_str(&format!(
+        "\t\tfmt.Fprintln(os.Stderr, \"[{trait_pascal}Bridge] host 'Version' called with an invalid handle\")\n"
+    ));
+    out.push_str("\t\t*outError = C.CString(\"invalid handle\")\n");
     out.push_str("\t\treturn 1\n");
     out.push_str("\t}\n");
     out.push_str("\tversion := impl.Version()\n");
@@ -366,6 +374,10 @@ pub(super) fn gen_plugin_trampolines(out: &mut String, trait_name: &str, trait_p
     ));
     out.push('\n');
     out.push_str("\tif !ok {\n");
+    out.push_str(&format!(
+        "\t\tfmt.Fprintln(os.Stderr, \"[{trait_pascal}Bridge] host 'Initialize' called with an invalid handle\")\n"
+    ));
+    out.push_str("\t\t*outError = C.CString(\"invalid handle\")\n");
     out.push_str("\t\treturn 1\n");
     out.push_str("\t}\n");
     out.push_str("\terr := impl.Initialize()\n");
@@ -404,6 +416,10 @@ pub(super) fn gen_plugin_trampolines(out: &mut String, trait_name: &str, trait_p
     ));
     out.push('\n');
     out.push_str("\tif !ok {\n");
+    out.push_str(&format!(
+        "\t\tfmt.Fprintln(os.Stderr, \"[{trait_pascal}Bridge] host 'Shutdown' called with an invalid handle\")\n"
+    ));
+    out.push_str("\t\t*outError = C.CString(\"invalid handle\")\n");
     out.push_str("\t\treturn 1\n");
     out.push_str("\t}\n");
     out.push_str("\terr := impl.Shutdown()\n");

--- a/src/backends/go/trait_bridge/orchestration.rs
+++ b/src/backends/go/trait_bridge/orchestration.rs
@@ -193,6 +193,7 @@ pub fn gen_trait_bridges_file(
     out.push_str("import (\n");
     out.push_str("\t\"encoding/json\"\n");
     out.push_str("\t\"fmt\"\n");
+    out.push_str("\t\"os\"\n");
     out.push_str("\t\"runtime/cgo\"\n");
     out.push_str("\t\"sync\"\n");
     out.push_str("\t\"unsafe\"\n");

--- a/src/backends/java/gen_bindings/trait_bridge.rs
+++ b/src/backends/java/gen_bindings/trait_bridge.rs
@@ -580,8 +580,9 @@ fn gen_bridge_file(
         // Optional<non-primitive>/Bytes neither (no value channel exists for
         // them on the C ABI). Fallible methods keep java's long-standing JSON
         // convention (outResult for non-Unit + outError) unchanged; note the
-        // pre-existing caveat that a fallible primitive return would declare
-        // an outResult the C slot doesn't carry — deliberately not touched
+        // pre-existing caveat that a fallible primitive, Bytes,
+        // Optional<non-primitive>, or Duration return would declare an
+        // outResult the C slot doesn't carry — deliberately not touched
         // here (no such bridged method exists).
         let (has_out_result, has_out_error) = if has_error {
             (!matches!(method.return_type, TypeRef::Unit), true)

--- a/src/backends/java/gen_bindings/trait_bridge.rs
+++ b/src/backends/java/gen_bindings/trait_bridge.rs
@@ -572,14 +572,29 @@ fn gen_bridge_file(
             }
         }
         let direct = direct_return(method);
+        let has_error = method.error_type.is_some();
 
-        // JSON convention only: outResult (non-Unit) + outError pointer params.
-        // Direct-value slots carry neither — the C signature is
-        // `fn(user_data, params...) -> <primitive>`.
-        if direct.is_none() {
-            if !matches!(method.return_type, TypeRef::Unit) {
-                method_type_params.push("MemorySegment.class".to_string());
-            }
+        // Out-pointer params must mirror the C vtable slot exactly
+        // (`ffi::trait_bridge::c_return_convention`): fallible methods keep the
+        // JSON convention (outResult for non-Unit + outError); infallible
+        // methods carry only what their slot declares — direct-value slots
+        // neither, Char/Path outResult only, Optional<non-primitive>/Bytes
+        // neither (no value channel exists for them on the C ABI).
+        let (has_out_result, has_out_error) = if has_error {
+            (!matches!(method.return_type, TypeRef::Unit), true)
+        } else if direct.is_some() {
+            (false, false)
+        } else {
+            (
+                infallible_slot_has_out_result(&method.return_type),
+                infallible_slot_has_out_error(&method.return_type),
+            )
+        };
+
+        if has_out_result {
+            method_type_params.push("MemorySegment.class".to_string());
+        }
+        if has_out_error {
             method_type_params.push("MemorySegment.class".to_string());
         }
 
@@ -595,10 +610,10 @@ fn gen_bridge_file(
                 func_desc_params.push("ValueLayout.JAVA_LONG".to_string());
             }
         }
-        if direct.is_none() {
-            if !matches!(method.return_type, TypeRef::Unit) {
-                func_desc_params.push("ValueLayout.ADDRESS".to_string());
-            }
+        if has_out_result {
+            func_desc_params.push("ValueLayout.ADDRESS".to_string());
+        }
+        if has_out_error {
             func_desc_params.push("ValueLayout.ADDRESS".to_string());
         }
 
@@ -657,12 +672,22 @@ fn gen_bridge_file(
                 }
             }
             let direct = direct_return(method);
-            // JSON convention only: direct-value handlers return the primitive
-            // itself, so they carry no outResult/outError params.
-            if direct.is_none() {
-                if !matches!(method.return_type, TypeRef::Unit) {
-                    sig_params.push("MemorySegment outResult".to_string());
-                }
+            let has_error = method.error_type.is_some();
+            // Mirror the C slot's out-pointer params exactly (see the stub loop).
+            let (has_out_result, has_out_error) = if has_error {
+                (!matches!(method.return_type, TypeRef::Unit), true)
+            } else if direct.is_some() {
+                (false, false)
+            } else {
+                (
+                    infallible_slot_has_out_result(&method.return_type),
+                    infallible_slot_has_out_error(&method.return_type),
+                )
+            };
+            if has_out_result {
+                sig_params.push("MemorySegment outResult".to_string());
+            }
+            if has_out_error {
                 sig_params.push("MemorySegment outError".to_string());
             }
 
@@ -745,6 +770,12 @@ fn gen_bridge_file(
                 direct_sig_return => direct_sig_return,
                 direct_return_stmt => direct_return_stmt,
                 direct_default_stmt => direct_default_stmt,
+                // JSON-convention slots without a value/error channel
+                // (infallible Char/Path lack outError; infallible
+                // Optional<non-primitive>/Bytes lack both): the handler's
+                // marshal/catch must not touch pointers the slot doesn't carry.
+                marshal_result => has_out_result,
+                has_out_error => has_out_error,
             }
         })
         .collect();
@@ -887,6 +918,35 @@ impl DirectReturn {
             DirectWrap::OptionalBoolToLong => format!("return {call}.orElse(false) ? 1L : 0L;"),
         }
     }
+}
+
+/// Whether an infallible slot for this return type carries an `out_result`
+/// pointer. Mirrors `ffi::trait_bridge::c_return_convention`'s out-param arms:
+/// String/Char/Path/Json/Named/Vec/Map get `out_result`; Optional<non-primitive>
+/// and Bytes fall into the catch-all arm with NO out params (a bare i32 return
+/// with no value channel — such methods cannot marshal a value at all).
+fn infallible_slot_has_out_result(ty: &TypeRef) -> bool {
+    matches!(
+        ty,
+        TypeRef::String
+            | TypeRef::Char
+            | TypeRef::Path
+            | TypeRef::Json
+            | TypeRef::Named(_)
+            | TypeRef::Vec(_)
+            | TypeRef::Map(_, _)
+    )
+}
+
+/// Whether an infallible slot for this return type carries an `out_error`
+/// pointer. Mirrors `c_return_convention`'s `needs_out_error`: only
+/// Named/Vec/Map/String/Json — notably NOT Char/Path, whose infallible slots
+/// have `out_result` but no `out_error`.
+fn infallible_slot_has_out_error(ty: &TypeRef) -> bool {
+    matches!(
+        ty,
+        TypeRef::Named(_) | TypeRef::Vec(_) | TypeRef::Map(_, _) | TypeRef::String | TypeRef::Json
+    )
 }
 
 /// Direct-value return shape for a type, or `None` when the method uses the

--- a/src/backends/java/gen_bindings/trait_bridge.rs
+++ b/src/backends/java/gen_bindings/trait_bridge.rs
@@ -574,12 +574,15 @@ fn gen_bridge_file(
         let direct = direct_return(method);
         let has_error = method.error_type.is_some();
 
-        // Out-pointer params must mirror the C vtable slot exactly
-        // (`ffi::trait_bridge::c_return_convention`): fallible methods keep the
-        // JSON convention (outResult for non-Unit + outError); infallible
-        // methods carry only what their slot declares — direct-value slots
-        // neither, Char/Path outResult only, Optional<non-primitive>/Bytes
-        // neither (no value channel exists for them on the C ABI).
+        // Out-pointer params mirror the C vtable slot
+        // (`ffi::trait_bridge::c_return_convention`) for infallible methods:
+        // direct-value slots carry neither pointer, Char/Path outResult only,
+        // Optional<non-primitive>/Bytes neither (no value channel exists for
+        // them on the C ABI). Fallible methods keep java's long-standing JSON
+        // convention (outResult for non-Unit + outError) unchanged; note the
+        // pre-existing caveat that a fallible primitive return would declare
+        // an outResult the C slot doesn't carry — deliberately not touched
+        // here (no such bridged method exists).
         let (has_out_result, has_out_error) = if has_error {
             (!matches!(method.return_type, TypeRef::Unit), true)
         } else if direct.is_some() {

--- a/src/backends/java/gen_bindings/trait_bridge.rs
+++ b/src/backends/java/gen_bindings/trait_bridge.rs
@@ -443,6 +443,20 @@ fn gen_bridge_file(
     let registry_field = format!("{}_BRIDGES", trait_snake.to_uppercase());
     let bridge_class = format!("{trait_pascal}Bridge");
 
+    // Sync infallible methods with simple returns use the C vtable's
+    // direct-value convention (see `ffi::trait_bridge::c_return_convention`):
+    // the slot is `fn(user_data, params...) -> <primitive>` with NO
+    // out_result/out_error pointers. The upcall stub and handler must match
+    // that ABI exactly — appending the JSON-convention pointer params here
+    // makes the stub read garbage registers as addresses (wild write) and
+    // Rust read the int status code as the return value.
+    let direct_return = |method: &MethodDef| -> Option<DirectReturn> {
+        if method.error_type.is_some() {
+            return None;
+        }
+        direct_return_for(&method.return_type)
+    };
+
     // Methods listed in `ffi_skip_methods` cannot be expressed on the C ABI
     // (e.g., trait-object references), so they are absent from the interface
     // and the bridge must not emit upcall stubs or handlers for them.
@@ -557,10 +571,17 @@ fn gen_bridge_file(
                 method_type_params.push("long.class".to_string());
             }
         }
-        if !matches!(method.return_type, TypeRef::Unit) {
+        let direct = direct_return(method);
+
+        // JSON convention only: outResult (non-Unit) + outError pointer params.
+        // Direct-value slots carry neither — the C signature is
+        // `fn(user_data, params...) -> <primitive>`.
+        if direct.is_none() {
+            if !matches!(method.return_type, TypeRef::Unit) {
+                method_type_params.push("MemorySegment.class".to_string());
+            }
             method_type_params.push("MemorySegment.class".to_string());
         }
-        method_type_params.push("MemorySegment.class".to_string());
 
         let mut func_desc_params = vec!["ValueLayout.ADDRESS".to_string()];
         for param in &method.params {
@@ -574,24 +595,40 @@ fn gen_bridge_file(
                 func_desc_params.push("ValueLayout.JAVA_LONG".to_string());
             }
         }
-        if !matches!(method.return_type, TypeRef::Unit) {
+        if direct.is_none() {
+            if !matches!(method.return_type, TypeRef::Unit) {
+                func_desc_params.push("ValueLayout.ADDRESS".to_string());
+            }
             func_desc_params.push("ValueLayout.ADDRESS".to_string());
         }
-        func_desc_params.push("ValueLayout.ADDRESS".to_string());
 
-        stubs.push(minijinja::context! {
-            var_name => &stub_name,
-            pascal_name => &method_pascal,
-            handle_name => &handle_name,
-            return_type => "int.class",
-            method_type_params => method_type_params.join(", "),
-            // Trait method stubs return i32 status codes, so the FunctionDescriptor return
-            // layout must be JAVA_INT (matching the `int` upcall return). The companion
-            // bytes-length param above stays JAVA_LONG.
-            descriptor_return => "ValueLayout.JAVA_INT",
-            descriptor_params => func_desc_params.join(", "),
-            returns_void => false,
-        });
+        match direct {
+            Some(d) => stubs.push(minijinja::context! {
+                var_name => &stub_name,
+                pascal_name => &method_pascal,
+                handle_name => &handle_name,
+                // Direct-value slot: the stub returns the primitive itself
+                // (or void), matching the vtable's `-> <primitive>` signature.
+                return_type => d.method_type_class,
+                method_type_params => method_type_params.join(", "),
+                descriptor_return => d.descriptor,
+                descriptor_params => func_desc_params.join(", "),
+                returns_void => d.returns_void,
+            }),
+            None => stubs.push(minijinja::context! {
+                var_name => &stub_name,
+                pascal_name => &method_pascal,
+                handle_name => &handle_name,
+                return_type => "int.class",
+                method_type_params => method_type_params.join(", "),
+                // JSON-convention stubs return i32 status codes, so the FunctionDescriptor
+                // return layout must be JAVA_INT (matching the `int` upcall return). The
+                // companion bytes-length param above stays JAVA_LONG.
+                descriptor_return => "ValueLayout.JAVA_INT",
+                descriptor_params => func_desc_params.join(", "),
+                returns_void => false,
+            }),
+        }
     }
 
     // Build trait method handlers
@@ -619,10 +656,15 @@ fn gen_bridge_file(
                     sig_params.push(format!("long {local}Len"));
                 }
             }
-            if !matches!(method.return_type, TypeRef::Unit) {
-                sig_params.push("MemorySegment outResult".to_string());
+            let direct = direct_return(method);
+            // JSON convention only: direct-value handlers return the primitive
+            // itself, so they carry no outResult/outError params.
+            if direct.is_none() {
+                if !matches!(method.return_type, TypeRef::Unit) {
+                    sig_params.push("MemorySegment outResult".to_string());
+                }
+                sig_params.push("MemorySegment outError".to_string());
             }
-            sig_params.push("MemorySegment outError".to_string());
 
             // Build unmarshal params
             let mut unmarshal_params: Vec<String> = vec![];
@@ -671,6 +713,25 @@ fn gen_bridge_file(
                 _ => false,
             };
 
+            let call = format!("impl.{}({})", method.name, java_args.join(", "));
+            let (is_direct, direct_sig_return, direct_return_stmt, direct_default_stmt) = match &direct {
+                Some(d) => (
+                    true,
+                    d.java_sig,
+                    if d.returns_void {
+                        format!("{call};")
+                    } else {
+                        d.return_stmt(&call)
+                    },
+                    if d.returns_void {
+                        String::new()
+                    } else {
+                        format!("return {};", d.default_literal)
+                    },
+                ),
+                None => (false, "", String::new(), String::new()),
+            };
+
             minijinja::context! {
                 name => &method.name,
                 handle_name => &handle,
@@ -680,6 +741,10 @@ fn gen_bridge_file(
                 call_args => java_args.join(", "),
                 has_return => has_return,
                 raw_result => raw_result,
+                direct => is_direct,
+                direct_sig_return => direct_sig_return,
+                direct_return_stmt => direct_return_stmt,
+                direct_default_stmt => direct_default_stmt,
             }
         })
         .collect();
@@ -779,6 +844,134 @@ fn gen_bridge_file(
     };
 
     template_env::render("trait_bridge.jinja", ctx)
+}
+
+/// Shape of a direct-value (non-JSON-convention) trait-method return.
+///
+/// Mirrors `ffi::trait_bridge::c_return_convention`'s infallible-simple branch:
+/// integer primitives (and Duration millis) return as 64-bit values, floats as
+/// themselves, Unit as void. Integer layouts are promoted to `JAVA_LONG` for
+/// the same JBR Win64 Panama reason documented on `java_ffi_type`.
+struct DirectReturn {
+    /// FunctionDescriptor return layout, e.g. `ValueLayout.JAVA_LONG`. Unused for void.
+    descriptor: &'static str,
+    /// MethodType return class literal, e.g. `long.class` / `void.class`.
+    method_type_class: &'static str,
+    /// Java handler signature return type, e.g. `long` / `void`.
+    java_sig: &'static str,
+    /// Default value returned when the host throws, e.g. `0L`. Empty for void.
+    default_literal: &'static str,
+    /// Wrap the `impl.method(args)` call expression into a return value
+    /// (boolean -> 1L/0L, Optional -> orElse(default)).
+    wrap: DirectWrap,
+    returns_void: bool,
+}
+
+enum DirectWrap {
+    /// `return <call>;` (implicit numeric widening covers narrow ints).
+    Plain,
+    /// `return <call> ? 1L : 0L;`
+    BoolToLong,
+    /// `return <call>.orElse(<default>);`
+    OptionalOrDefault,
+    /// `return <call>.orElse(false) ? 1L : 0L;`
+    OptionalBoolToLong,
+}
+
+impl DirectReturn {
+    fn return_stmt(&self, call: &str) -> String {
+        match self.wrap {
+            DirectWrap::Plain => format!("return {call};"),
+            DirectWrap::BoolToLong => format!("return {call} ? 1L : 0L;"),
+            DirectWrap::OptionalOrDefault => format!("return {call}.orElse({});", self.default_literal),
+            DirectWrap::OptionalBoolToLong => format!("return {call}.orElse(false) ? 1L : 0L;"),
+        }
+    }
+}
+
+/// Direct-value return shape for a type, or `None` when the method uses the
+/// JSON out-param convention (String/Named/Vec/Map/Json returns).
+fn direct_return_for(ty: &TypeRef) -> Option<DirectReturn> {
+    fn for_prim(p: &PrimitiveType, optional: bool) -> DirectReturn {
+        match p {
+            PrimitiveType::Bool => DirectReturn {
+                descriptor: "ValueLayout.JAVA_LONG",
+                method_type_class: "long.class",
+                java_sig: "long",
+                default_literal: "0L",
+                wrap: if optional {
+                    DirectWrap::OptionalBoolToLong
+                } else {
+                    DirectWrap::BoolToLong
+                },
+                returns_void: false,
+            },
+            PrimitiveType::F32 => DirectReturn {
+                descriptor: "ValueLayout.JAVA_FLOAT",
+                method_type_class: "float.class",
+                java_sig: "float",
+                default_literal: "0.0f",
+                wrap: if optional {
+                    DirectWrap::OptionalOrDefault
+                } else {
+                    DirectWrap::Plain
+                },
+                returns_void: false,
+            },
+            PrimitiveType::F64 => DirectReturn {
+                descriptor: "ValueLayout.JAVA_DOUBLE",
+                method_type_class: "double.class",
+                java_sig: "double",
+                default_literal: "0.0d",
+                wrap: if optional {
+                    DirectWrap::OptionalOrDefault
+                } else {
+                    DirectWrap::Plain
+                },
+                returns_void: false,
+            },
+            // All integer widths (widening to long is implicit in Java).
+            _ => DirectReturn {
+                descriptor: "ValueLayout.JAVA_LONG",
+                method_type_class: "long.class",
+                java_sig: "long",
+                default_literal: "0L",
+                wrap: if optional {
+                    DirectWrap::OptionalOrDefault
+                } else {
+                    DirectWrap::Plain
+                },
+                returns_void: false,
+            },
+        }
+    }
+
+    match ty {
+        TypeRef::Unit => Some(DirectReturn {
+            descriptor: "",
+            method_type_class: "void.class",
+            java_sig: "void",
+            default_literal: "",
+            wrap: DirectWrap::Plain,
+            returns_void: true,
+        }),
+        TypeRef::Primitive(p) => Some(for_prim(p, false)),
+        // Duration crosses the C ABI as u64 millis; the Java type is boxed Long,
+        // which unboxes implicitly on return.
+        TypeRef::Duration => Some(DirectReturn {
+            descriptor: "ValueLayout.JAVA_LONG",
+            method_type_class: "long.class",
+            java_sig: "long",
+            default_literal: "0L",
+            wrap: DirectWrap::Plain,
+            returns_void: false,
+        }),
+        TypeRef::Optional(inner) => match inner.as_ref() {
+            TypeRef::Primitive(p) => Some(for_prim(p, true)),
+            _ => None,
+        },
+        _ => None,
+    }
 }
 
 /// Format unmarshal code for a single parameter without writing to a string.

--- a/src/backends/java/templates/trait_bridge.jinja
+++ b/src/backends/java/templates/trait_bridge.jinja
@@ -94,6 +94,25 @@ public final class {{ bridge_class }} implements AutoCloseable {
 
 {% endfor %}{% endif %}
 {% for method in methods %}
+{% if method.direct %}
+    // Direct-value C slot (`fn(user_data, params...) -> <primitive>`): the value
+    // returns straight through the ABI with no out_result/out_error pointers,
+    // so a host exception cannot propagate — log it before substituting the
+    // default, which would otherwise be indistinguishable from a real result.
+    private {{ method.direct_sig_return }} {{ method.handle_name }}({{ method.sig_params }}) {
+        try {
+{% for unmarshal in method.unmarshal_params %}
+            {{ unmarshal }}
+{% endfor %}
+            {{ method.direct_return_stmt }}
+        } catch (Throwable e) {
+            System.err.println("[{{ bridge_class }}] host '{{ method.name }}' threw{% if method.direct_default_stmt %}; returning default{% endif %}: " + e);
+{% if method.direct_default_stmt %}
+            {{ method.direct_default_stmt }}
+{% endif %}
+        }
+    }
+{% else %}
     private int {{ method.handle_name }}({{ method.sig_params }}) {
         try {
 {% for unmarshal in method.unmarshal_params %}
@@ -117,6 +136,7 @@ public final class {{ bridge_class }} implements AutoCloseable {
             return 1;
         }
     }
+{% endif %}
 
 {% endfor %}
     private void writeError(MemorySegment outError, Throwable e) {

--- a/src/backends/java/templates/trait_bridge.jinja
+++ b/src/backends/java/templates/trait_bridge.jinja
@@ -118,7 +118,7 @@ public final class {{ bridge_class }} implements AutoCloseable {
 {% for unmarshal in method.unmarshal_params %}
             {{ unmarshal }}
 {% endfor %}
-{% if method.has_return %}
+{% if method.has_return and method.marshal_result %}
             {{ method.return_type }} callbackResult = impl.{{ method.name }}({{ method.call_args }});
 {% if method.raw_result %}
             MemorySegment jsonCs = arena.allocateFrom(callbackResult);
@@ -127,12 +127,21 @@ public final class {{ bridge_class }} implements AutoCloseable {
             MemorySegment jsonCs = arena.allocateFrom(json);
 {% endif %}
             outResult.set(ValueLayout.ADDRESS, 0, jsonCs);
+{% elif method.has_return %}
+            // This slot has no out_result channel on the C ABI (infallible
+            // Optional<non-primitive>/Bytes return) — the value cannot be
+            // marshaled; the call still runs for its effects.
+            impl.{{ method.name }}({{ method.call_args }});
 {% else %}
             impl.{{ method.name }}({{ method.call_args }});
 {% endif %}
             return 0;
         } catch (Throwable e) {
+{% if method.has_out_error %}
             writeError(outError, e);
+{% else %}
+            System.err.println("[{{ bridge_class }}] host '{{ method.name }}' threw: " + e);
+{% endif %}
             return 1;
         }
     }

--- a/src/backends/jni/templates/trait_bridge_method_body.rs.jinja
+++ b/src/backends/jni/templates/trait_bridge_method_body.rs.jinja
@@ -10,7 +10,10 @@ let __resp = match self.__alef_dispatch("{{ method_name }}", &args_json) {
 {% if has_error %}
         return Err({{ dispatch_error_expr }});
 {% else %}
-        let _ = e;
+        // This method's Rust signature is infallible, so a dispatch failure
+        // cannot propagate. Log before substituting the default — a silent
+        // default is indistinguishable from a real result to the caller.
+        eprintln!("[{{ wrapper }}] dispatch of host '{{ method_name }}' failed; returning default: {e}");
         return Default::default();
 {% endif %}
     }
@@ -21,7 +24,7 @@ let mut __value: serde_json::Value = match serde_json::from_str(&__resp) {
 {% if has_error %}
         return Err({{ parse_error_expr }});
 {% else %}
-        let _ = e;
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned invalid JSON; returning default: {e}");
         return Default::default();
 {% endif %}
     }
@@ -30,7 +33,7 @@ if let Some(e) = __value.get("err").and_then(|v| v.as_str()) {
 {% if has_error %}
     return Err({{ host_error_expr }});
 {% else %}
-    let _ = e;
+    eprintln!("[{{ wrapper }}] host '{{ method_name }}' threw; returning default: {e}");
     return Default::default();
 {% endif %}
 }
@@ -46,6 +49,9 @@ let __ok = __value
 {% if has_error %}
 serde_json::from_value::<{{ return_ty }}>(__ok).map_err(|e| {{ deser_error_expr }})
 {% else %}
-serde_json::from_value::<{{ return_ty }}>(__ok).unwrap_or_default()
+serde_json::from_value::<{{ return_ty }}>(__ok).unwrap_or_else(|e| {
+    eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned a value that does not match the expected return type; returning default: {e}");
+    Default::default()
+})
 {% endif %}
 {% endif %}

--- a/src/backends/jni/trait_bridge.rs
+++ b/src/backends/jni/trait_bridge.rs
@@ -82,6 +82,7 @@ impl JniBridgeGenerator {
             "trait_bridge_method_body.rs.jinja",
             minijinja::context! {
                 method_name => name,
+                wrapper => spec.wrapper_name(),
                 args => args,
                 has_error => has_error,
                 is_unit => is_unit,

--- a/src/backends/magnus/templates/sync_method_body.rs.jinja
+++ b/src/backends/magnus/templates/sync_method_body.rs.jinja
@@ -7,7 +7,10 @@ let val: magnus::Value = match {{ call }} {
         {%- if has_error %}
         return Err({{ err_expr }});
         {%- else %}
-        let _ = e;
+        // This method's Rust signature is infallible, so a Ruby exception cannot
+        // propagate. Log before substituting the default — a silent default is
+        // indistinguishable from a real result to the caller.
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' raised; returning default: {e}");
         return Default::default();
         {%- endif %}
     }

--- a/src/backends/magnus/templates/trait_bridge_return_conversion.rs.jinja
+++ b/src/backends/magnus/templates/trait_bridge_return_conversion.rs.jinja
@@ -6,7 +6,10 @@
 {{ indent }}    .map(Into::into)
 {{ indent }}    .map_err(|e| {{ err_convert }})
 {% else %}
-{{ indent }}<{{ native_return_binding }} as magnus::TryConvert>::try_convert(val).map(Into::into).unwrap_or_default()
+{{ indent }}<{{ native_return_binding }} as magnus::TryConvert>::try_convert(val).map(Into::into).unwrap_or_else(|e| {
+{{ indent }}    eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned an unconvertible value; returning default: {e}");
+{{ indent }}    Default::default()
+{{ indent }}})
 {%- endif %}
 {%- elif needs_json %}
 {{ indent }}let json_str: String = if let Ok(s) = <String as magnus::TryConvert>::try_convert(val) {
@@ -18,7 +21,7 @@
 {%- if has_error %}
 {{ indent }}            return Err({{ err_non_json }});
 {%- else %}
-{{ indent }}            let _ = e;
+{{ indent }}            eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned a non-JSON value; returning default: {e}");
 {{ indent }}            return Default::default();
 {%- endif %}
 {{ indent }}        }
@@ -28,13 +31,19 @@
 {{ indent }}serde_json::from_str::<{{ rust_ty }}>(&json_str)
 {{ indent }}    .map_err(|e| {{ err_deserialize }})
 {%- else %}
-{{ indent }}serde_json::from_str::<{{ rust_ty }}>(&json_str).unwrap_or_default()
+{{ indent }}serde_json::from_str::<{{ rust_ty }}>(&json_str).unwrap_or_else(|e| {
+{{ indent }}    eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned an unparseable value; returning default: {e}");
+{{ indent }}    Default::default()
+{{ indent }}})
 {%- endif %}
 {%- else %}
 {%- if has_error %}
 {{ indent }}<{{ rust_ty }} as magnus::TryConvert>::try_convert(val)
 {{ indent }}    .map_err(|e| {{ err_convert }})
 {%- else %}
-{{ indent }}<{{ rust_ty }} as magnus::TryConvert>::try_convert(val).unwrap_or_default()
+{{ indent }}<{{ rust_ty }} as magnus::TryConvert>::try_convert(val).unwrap_or_else(|e| {
+{{ indent }}    eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned an unconvertible value; returning default: {e}");
+{{ indent }}    Default::default()
+{{ indent }}})
 {%- endif %}
 {%- endif %}

--- a/src/backends/magnus/trait_bridge/bridge_generator.rs
+++ b/src/backends/magnus/trait_bridge/bridge_generator.rs
@@ -231,7 +231,7 @@ impl TraitBridgeGenerator for MagnusBridgeGenerator {
         ]
     }
 
-    fn gen_sync_method_body(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> String {
+    fn gen_sync_method_body(&self, method: &MethodDef, spec: &TraitBridgeSpec) -> String {
         let name = &method.name;
         let has_error = method.error_type.is_some();
         let is_unit = matches!(method.return_type, TypeRef::Unit);
@@ -259,6 +259,8 @@ impl TraitBridgeGenerator for MagnusBridgeGenerator {
         let mut body = crate::backends::magnus::template_env::render(
             "sync_method_body.rs.jinja",
             minijinja::context! {
+                wrapper => spec.wrapper_name(),
+                method_name => name,
                 call => call,
                 has_error => has_error,
                 is_unit => is_unit,
@@ -267,13 +269,13 @@ impl TraitBridgeGenerator for MagnusBridgeGenerator {
         );
 
         if !is_unit {
-            body.push_str(&self.return_conversion(method, has_error, ""));
+            body.push_str(&self.return_conversion(method, spec, has_error, ""));
         }
 
         body
     }
 
-    fn gen_async_method_body(&self, method: &MethodDef, _spec: &TraitBridgeSpec) -> String {
+    fn gen_async_method_body(&self, method: &MethodDef, spec: &TraitBridgeSpec) -> String {
         let name = &method.name;
         let has_error = method.error_type.is_some();
         let is_unit = matches!(method.return_type, TypeRef::Unit);
@@ -361,7 +363,7 @@ let cached_name_for_blocking = cached_name.clone();\n\
                 result_ty => result_ty,
                 err_expr_call => err_expr_call,
                 err_expr_join => err_expr_join,
-                return_conversion => self.return_conversion(method, has_error, "            "),
+                return_conversion => self.return_conversion(method, spec, has_error, "            "),
             },
         )
     }
@@ -528,7 +530,7 @@ impl MagnusBridgeGenerator {
     /// Emit code that converts the Ruby `val` (in scope) into the Rust return type
     /// and either returns it (if has_error: false) or wraps it in `Ok(...)` (if has_error: true).
     /// For sync bodies — no leading whitespace.
-    fn return_conversion(&self, method: &MethodDef, has_error: bool, indent: &str) -> String {
+    fn return_conversion(&self, method: &MethodDef, spec: &TraitBridgeSpec, has_error: bool, indent: &str) -> String {
         let rust_ty = self.return_rust_type(&method.return_type);
         let err_non_json = if has_error {
             self.make_error(&format!(
@@ -558,6 +560,8 @@ impl MagnusBridgeGenerator {
         crate::backends::magnus::template_env::render(
             "trait_bridge_return_conversion.rs.jinja",
             minijinja::context! {
+                wrapper => spec.wrapper_name(),
+                method_name => &method.name,
                 has_error => has_error,
                 needs_json => self.needs_json_marshalling(&method.return_type),
                 native_return_binding => self.native_struct_return(&method.return_type),

--- a/src/backends/napi/templates/sync_method_non_unit_return.jinja
+++ b/src/backends/napi/templates/sync_method_non_unit_return.jinja
@@ -72,10 +72,9 @@ match result {
             }
         };
         match s.as_str() {
-            "" | "null" => {
-                eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned null/undefined; returning default");
-                Default::default()
-            }
+            // null/undefined is a legitimate "no value" answer for infallible
+            // returns (mirrors the extendr backend) — no log.
+            "" | "null" => Default::default(),
             _ => match serde_json::from_str::<_>(&s) {
                 Ok(v) => v,
                 Err(e) => {

--- a/src/backends/napi/templates/sync_method_non_unit_return.jinja
+++ b/src/backends/napi/templates/sync_method_non_unit_return.jinja
@@ -53,16 +53,36 @@ match result {
 }
 {% else %}
 match result {
-    Err(_) => Default::default(),
+    // This method's Rust signature is infallible, so a JS exception cannot
+    // propagate. Log before substituting the default — a silent default is
+    // indistinguishable from a real result to the caller.
+    Err(e) => {
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' threw; returning default: {e}");
+        Default::default()
+    }
     Ok(val) => {
         // Convert JS value to Rust type via string coercion
-        let s = val.coerce_to_string()
+        let s = match val.coerce_to_string()
             .and_then(|s| s.into_utf8())
-            .and_then(|s| s.into_owned())
-            .unwrap_or_default();
+            .and_then(|s| s.into_owned()) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned a value that could not be coerced to a string; returning default: {e}");
+                return Default::default();
+            }
+        };
         match s.as_str() {
-            "" | "null" => Default::default(),
-            _ => serde_json::from_str::<_>(&s).unwrap_or_default()
+            "" | "null" => {
+                eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned null/undefined; returning default");
+                Default::default()
+            }
+            _ => match serde_json::from_str::<_>(&s) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned an unparseable value; returning default: {e}");
+                    Default::default()
+                }
+            }
         }
     }
 }

--- a/src/backends/napi/templates/sync_method_unit_return.jinja
+++ b/src/backends/napi/templates/sync_method_unit_return.jinja
@@ -37,7 +37,11 @@ match result {
 }
 {% else %}
 match result {
-    Err(_) => Default::default(),
+    // Infallible unit method: a JS exception cannot propagate — log it before
+    // discarding so a failed callback is not invisible to the caller.
+    Err(e) => {
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' threw; ignoring: {e}");
+    }
     Ok(_) => ()
 }
 {% endif %}

--- a/src/backends/napi/trait_bridge/bridge_generator.rs
+++ b/src/backends/napi/trait_bridge/bridge_generator.rs
@@ -107,6 +107,7 @@ impl TraitBridgeGenerator for NapiBridgeGenerator {
             crate::backends::napi::template_env::render(
                 "sync_method_unit_return.jinja",
                 minijinja::context! {
+                    wrapper => spec.wrapper_name(),
                     method_name => &js_method_name,
                     snake_case_method_name => &snake_method_name,
                     args_tuple_ty => args_tuple_ty,
@@ -122,6 +123,7 @@ impl TraitBridgeGenerator for NapiBridgeGenerator {
             crate::backends::napi::template_env::render(
                 "sync_method_non_unit_return.jinja",
                 minijinja::context! {
+                    wrapper => spec.wrapper_name(),
                     method_name => &js_method_name,
                     snake_case_method_name => &snake_method_name,
                     args_tuple_ty => args_tuple_ty,

--- a/src/backends/php/templates/sync_method_body.jinja
+++ b/src/backends/php/templates/sync_method_body.jinja
@@ -38,26 +38,60 @@ match result {
 {% if is_unit_return %}
     Ok(_) => (),
 {% elif is_primitive_return %}
+    Ok(val) => match val.long() {
 {% if return_type == "bool" %}
-    Ok(val) => val.long().unwrap_or_default() != 0,
+        Some(v) => v != 0,
 {% else %}
-    Ok(val) => val.long().unwrap_or_default() as {{ return_type }},
+        Some(v) => v as {{ return_type }},
 {% endif %}
+        None => {
+            eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned a non-integer value; returning default");
+            Default::default()
+        }
+    },
 {% else %}
     Ok(val) => {
 {%- if native_return_binding %}
         if let Some(native) = <&{{ native_return_binding }} as ext_php_rs::convert::FromZval>::from_zval(&val) {
             native.clone().into()
         } else {
-            let json_str = val.string().unwrap_or_default();
-            serde_json::from_str(&json_str).unwrap_or_default()
+            match val.string() {
+                Some(json_str) => match serde_json::from_str(&json_str) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned an unparseable value; returning default: {e}");
+                        Default::default()
+                    }
+                },
+                None => {
+                    eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned a non-string value; returning default");
+                    Default::default()
+                }
+            }
         }
 {%- else %}
-        let json_str = val.string().unwrap_or_default();
-        serde_json::from_str(&json_str).unwrap_or_default()
+        match val.string() {
+            Some(json_str) => match serde_json::from_str(&json_str) {
+                Ok(v) => v,
+                Err(e) => {
+                    eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned an unparseable value; returning default: {e}");
+                    Default::default()
+                }
+            },
+            None => {
+                eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned a non-string value; returning default");
+                Default::default()
+            }
+        }
 {%- endif %}
     }
 {% endif %}
-    Err(_) => Default::default(),
+    // This method's Rust signature is infallible, so a PHP exception cannot
+    // propagate. Log before substituting the default — a silent default is
+    // indistinguishable from a real result to the caller.
+    Err(e) => {
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' threw; {% if is_unit_return %}ignoring{% else %}returning default{% endif %}: {e}");
+        Default::default()
+    }
 }
 {% endif %}

--- a/src/backends/php/trait_bridge/generator.rs
+++ b/src/backends/php/trait_bridge/generator.rs
@@ -166,6 +166,7 @@ impl TraitBridgeGenerator for PhpBridgeGenerator {
         crate::backends::php::template_env::render(
             "sync_method_body.jinja",
             context! {
+                wrapper => spec.wrapper_name(),
                 method_name => name,
                 args_expr => args_expr,
                 is_result_type => is_result_type,

--- a/src/backends/pyo3/templates/trait_bridge/sync_method_non_unit_return.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/sync_method_non_unit_return.jinja
@@ -26,6 +26,15 @@ Python::attach(|py| {
 {% if has_error %}
         .map_err(|e| {{ error_expr }})
 {% else %}
-        .unwrap_or_default()
+        .unwrap_or_else(|e| {
+            // This method's Rust signature is infallible, so a host exception
+            // cannot propagate. Log it before substituting the default value —
+            // a silent default is indistinguishable from a real result to the
+            // caller (e.g. a zero token count reads as "fits any budget").
+            eprintln!(
+                "[{{ wrapper }}] host '{{ method_name }}' raised; returning default: {e}"
+            );
+            Default::default()
+        })
 {% endif %}
 })

--- a/src/backends/pyo3/templates/trait_bridge/sync_method_unit_return.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/sync_method_unit_return.jinja
@@ -10,6 +10,13 @@ Python::attach(|py| {
 {% if has_error %}
         .map_err(|e| {{ error_expr }})
 {% else %}
-        .unwrap_or(())
+        .unwrap_or_else(|e| {
+            // This method's Rust signature is infallible, so a host exception
+            // cannot propagate. Log it before discarding — a silently dropped
+            // callback failure is invisible to the caller.
+            eprintln!(
+                "[{{ wrapper }}] host '{{ method_name }}' raised; ignoring: {e}"
+            );
+        })
 {% endif %}
 })

--- a/src/backends/pyo3/templates/trait_bridge/visitor_method.jinja
+++ b/src/backends/pyo3/templates/trait_bridge/visitor_method.jinja
@@ -6,7 +6,12 @@ fn {{ method_name }}({{ sig }}) -> {{ ret_ty }} {
         }
 
         match {{ py_call }} {
-            Err(_) => {{ default_result_expr }},
+            // Visitor callbacks are infallible on the Rust side — log the host
+            // exception before substituting the default action.
+            Err(e) => {
+                eprintln!("[{{ wrapper }}] host '{{ method_name }}' raised; using default action: {e}");
+                {{ default_result_expr }}
+            }
             Ok(result) => {
                 if let Ok(s) = result.extract::<String>() {
                     match s.as_str() {
@@ -22,7 +27,10 @@ fn {{ method_name }}({{ sig }}) -> {{ ret_ty }} {
                     if let Ok(d) = py_dict {
 {%- for variant in payload_result_variants %}
                         if let Some(v) = d.get_item("{{ variant.wire_name }}").ok().flatten() {
-                            return {{ ret_ty }}::{{ variant.name }}(v.extract::<String>().unwrap_or_default());
+                            return {{ ret_ty }}::{{ variant.name }}(v.extract::<String>().unwrap_or_else(|e| {
+                                eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned a non-string '{{ variant.wire_name }}' payload; using empty string: {e}");
+                                String::new()
+                            }));
                         }
 {%- endfor %}
                         {{ default_result_expr }}

--- a/src/backends/pyo3/trait_bridge/generator.rs
+++ b/src/backends/pyo3/trait_bridge/generator.rs
@@ -96,6 +96,7 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
                     run_args => run_args,
                     has_error => has_error,
                     error_expr => error_expr,
+                    wrapper => spec.wrapper_name(),
                 },
             )
         } else {
@@ -120,6 +121,7 @@ impl TraitBridgeGenerator for Pyo3BridgeGenerator {
                     has_error => has_error,
                     error_expr => error_expr,
                     deserialize_error_expr => deserialize_error_expr,
+                    wrapper => spec.wrapper_name(),
                 },
             )
         }

--- a/src/backends/pyo3/trait_bridge/visitor_bridge.rs
+++ b/src/backends/pyo3/trait_bridge/visitor_bridge.rs
@@ -46,6 +46,7 @@ pub(super) fn gen_visitor_bridge(
             trait_path,
             bridge_cfg,
             type_paths,
+            struct_name,
             &result_metadata,
         );
     }
@@ -75,6 +76,7 @@ fn gen_visitor_method(
     _trait_path: &str,
     bridge_cfg: &TraitBridgeConfig,
     type_paths: &HashMap<String, String>,
+    struct_name: &str,
     result_metadata: &crate::codegen::visitor_result::VisitorResultMetadata,
 ) {
     use crate::core::ir::TypeRef;
@@ -111,6 +113,7 @@ fn gen_visitor_method(
     let method_code = crate::backends::pyo3::template_env::render(
         "trait_bridge/visitor_method.jinja",
         minijinja::context! {
+            wrapper => struct_name,
             method_name => name,
             sig => sig,
             ret_ty => ret_ty,

--- a/src/backends/rustler/templates/trait_sync_method_body.rs.jinja
+++ b/src/backends/rustler/templates/trait_sync_method_body.rs.jinja
@@ -27,7 +27,21 @@ match rx.blocking_recv() {
     Ok(Err(msg)) => Err({{ error_msg }}),
     Err(_) => Err({{ error_closed }})
 {%- else %}
-    Ok(Ok(json)) => serde_json::from_str(&json).unwrap_or_default(),
-    _ => Default::default()
+    // This method's Rust signature is infallible, so a host failure cannot
+    // propagate. Log each failure before substituting the default — a silent
+    // default is indistinguishable from a real result to the caller.
+    Ok(Ok(json)) => serde_json::from_str(&json).unwrap_or_else(|e| {
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' returned an unparseable value; returning default: {e}");
+        Default::default()
+    }),
+    // The host side already logs its own raises in detail, so keep this brief.
+    Ok(Err(_msg)) => {
+        eprintln!("[{{ wrapper }}] host '{{ method_name }}' raised (details in host log); returning default");
+        Default::default()
+    }
+    Err(_) => {
+        eprintln!("[{{ wrapper }}] reply channel for host '{{ method_name }}' closed before a reply arrived (host process exited or dropped the call); returning default");
+        Default::default()
+    }
 {%- endif %}
 }

--- a/src/backends/rustler/trait_bridge/methods.rs
+++ b/src/backends/rustler/trait_bridge/methods.rs
@@ -132,6 +132,7 @@ impl RustlerBridgeGenerator {
             .replace("{msg}", "\"Channel closed before reply received\".to_string()");
 
         minijinja::context! {
+            wrapper => spec.wrapper_name(),
             native_args => native_args,
             method_name => method.name,
             has_error => has_error,

--- a/src/backends/wasm/templates/gen_sync_method_body.jinja
+++ b/src/backends/wasm/templates/gen_sync_method_body.jinja
@@ -1,9 +1,26 @@
+{% if not has_error %}
+// This method's Rust signature is infallible, so a host failure cannot
+// propagate. eprintln! is invisible in browsers, so log to the JS console
+// before substituting the default — a silent default is indistinguishable
+// from a real result to the caller.
+fn __log_host_failure(msg: &str) {
+    let global = js_sys::global();
+    if let Ok(console) = js_sys::Reflect::get(&global, &wasm_bindgen::JsValue::from_str("console")) {
+        if let Ok(error_fn) = js_sys::Reflect::get(&console, &wasm_bindgen::JsValue::from_str("error")) {
+            if let Ok(error_fn) = error_fn.dyn_into::<js_sys::Function>() {
+                let _ = error_fn.call1(&console, &wasm_bindgen::JsValue::from_str(msg));
+            }
+        }
+    }
+}
+{% endif %}
 let key = wasm_bindgen::JsValue::from_str("{{ js_name }}");
 let has_method = js_sys::Reflect::has(&self.inner, &key).unwrap_or(false);
 if !has_method {
 {% if has_error %}
     return Err({{ error_expr }});
 {% else %}
+    __log_host_failure("[{{ wrapper }}] host method '{{ js_name }}' is missing; returning default");
     return Default::default();
 {% endif %}
 }
@@ -14,7 +31,10 @@ let func_val = js_sys::Reflect::get(&self.inner, &key)
 {% else %}
 let func_val = match js_sys::Reflect::get(&self.inner, &key) {
     Ok(f) => f,
-    Err(_) => return Default::default(),
+    Err(e) => {
+        __log_host_failure(&format!("[{{ wrapper }}] failed to get host method '{{ js_name }}'; returning default: {e:?}"));
+        return Default::default();
+    }
 };
 {% endif %}
 
@@ -24,7 +44,10 @@ let func: js_sys::Function = func_val.dyn_into()
 {% else %}
 let func: js_sys::Function = match func_val.dyn_into() {
     Ok(f) => f,
-    Err(_) => return Default::default(),
+    Err(_) => {
+        __log_host_failure("[{{ wrapper }}] host '{{ js_name }}' is not a function; returning default");
+        return Default::default();
+    }
 };
 {% endif %}
 
@@ -41,7 +64,10 @@ let result = func.apply(&self.inner, &args)
 {% else %}
 let result = match func.apply(&self.inner, &args) {
     Ok(r) => r,
-    Err(_) => return Default::default(),
+    Err(e) => {
+        __log_host_failure(&format!("[{{ wrapper }}] host '{{ js_name }}' threw; returning default: {e:?}"));
+        return Default::default();
+    }
 };
 {% endif %}
 
@@ -57,7 +83,13 @@ Ok(())
 result.as_string()
     .ok_or_else(|| {{ error_string_conv }})
 {% else %}
-result.as_string().unwrap_or_default()
+match result.as_string() {
+    Some(s) => s,
+    None => {
+        __log_host_failure("[{{ wrapper }}] host '{{ js_name }}' returned a non-string value; returning default");
+        Default::default()
+    }
+}
 {% endif %}
 {% elif return_bool %}
 // Convert JS boolean to Rust bool
@@ -65,7 +97,13 @@ result.as_string().unwrap_or_default()
 result.as_bool()
     .ok_or_else(|| {{ error_result_conv }})
 {% else %}
-result.as_bool().unwrap_or_default()
+match result.as_bool() {
+    Some(b) => b,
+    None => {
+        __log_host_failure("[{{ wrapper }}] host '{{ js_name }}' returned a non-boolean value; returning default");
+        Default::default()
+    }
+}
 {% endif %}
 {% elif return_enum %}
 // Convert bare enum string (non-JSON) to {{ ret_ty }}
@@ -74,7 +112,19 @@ result.as_string()
     .ok_or_else(|| {{ error_result_conv }})
     .and_then(|s| serde_json::from_str::<{{ ret_ty }}>(&format!("\"{}\"", s)).map_err(|e| {{ error_deser }}))
 {% else %}
-result.as_string().and_then(|s| serde_json::from_str::<{{ ret_ty }}>(&format!("\"{}\"", s)).ok()).unwrap_or_default()
+match result.as_string() {
+    Some(s) => match serde_json::from_str::<{{ ret_ty }}>(&format!("\"{}\"", s)) {
+        Ok(v) => v,
+        Err(e) => {
+            __log_host_failure(&format!("[{{ wrapper }}] host '{{ js_name }}' returned an unparseable value; returning default: {e}"));
+            Default::default()
+        }
+    },
+    None => {
+        __log_host_failure("[{{ wrapper }}] host '{{ js_name }}' returned a non-string value; returning default");
+        Default::default()
+    }
+}
 {% endif %}
 {% else %}
 // Convert JS result to {{ ret_ty }}
@@ -83,6 +133,18 @@ result.as_string()
     .ok_or_else(|| {{ error_result_conv }})
     .and_then(|s| serde_json::from_str::<{{ ret_ty }}>(&s).map_err(|e| {{ error_deser }}))
 {% else %}
-result.as_string().and_then(|s| serde_json::from_str::<{{ ret_ty }}>(&s).ok()).unwrap_or_default()
+match result.as_string() {
+    Some(s) => match serde_json::from_str::<{{ ret_ty }}>(&s) {
+        Ok(v) => v,
+        Err(e) => {
+            __log_host_failure(&format!("[{{ wrapper }}] host '{{ js_name }}' returned an unparseable value; returning default: {e}"));
+            Default::default()
+        }
+    },
+    None => {
+        __log_host_failure("[{{ wrapper }}] host '{{ js_name }}' returned a non-string value; returning default");
+        Default::default()
+    }
+}
 {% endif %}
 {% endif %}

--- a/src/backends/wasm/trait_bridge.rs
+++ b/src/backends/wasm/trait_bridge.rs
@@ -151,6 +151,7 @@ impl TraitBridgeGenerator for WasmBridgeGenerator {
             return_unit => return_unit,
             return_string => return_string,
             return_bool => return_bool,
+            wrapper => spec.wrapper_name(),
             return_enum => return_enum,
         };
         crate::backends::wasm::template_env::render("gen_sync_method_body", ctx)

--- a/tests/backends_go_gen_bindings/trait_bridge.rs
+++ b/tests/backends_go_gen_bindings/trait_bridge.rs
@@ -992,16 +992,26 @@ fn test_gen_trait_bridges_file_trampolines_recover_host_panics() {
         code.contains("host 'CountTokens' panicked; returning default"),
         "infallible trampoline must log the panic and return the default:\n{code}"
     );
-    // Named return so the deferred recover can set it.
+    // Named returns so the deferred recover can set them: int32 status for
+    // fallible slots, the primitive itself for direct-value slots.
     assert!(
-        code.contains("(ret C.int32_t)") || code.contains("(ret C."),
-        "trampolines must use a named return for the recover path:\n{code}"
+        code.contains("(ret C.int32_t)"),
+        "fallible trampolines must use a named int32 status return:\n{code}"
     );
-    // Invalid-handle paths must not fabricate a value and must write outError
-    // (or log) instead of a bare status.
+    assert!(
+        code.contains("(ret C.uintptr_t)"),
+        "usize trampolines must use a named primitive return:\n{code}"
+    );
+    // Invalid-handle paths must log AND marshal outError (lifecycle slots) —
+    // not return a bare status.
     assert!(
         code.contains("called with an invalid handle"),
         "invalid-handle paths must log:\n{code}"
+    );
+    assert!(
+        code.contains("host 'Name' called with an invalid handle")
+            && code.contains("*outError = C.CString(\"invalid handle\")"),
+        "lifecycle invalid-handle paths must marshal outError:\n{code}"
     );
     // Plugin lifecycle trampolines are covered too.
     assert!(

--- a/tests/backends_go_gen_bindings/trait_bridge.rs
+++ b/tests/backends_go_gen_bindings/trait_bridge.rs
@@ -934,3 +934,78 @@ fn test_generate_bindings_with_trait_bridge_emits_trait_bridges_go_file() {
 
 #[path = "trait_bridge/typed_params.rs"]
 mod typed_params;
+
+#[test]
+fn test_gen_trait_bridges_file_trampolines_recover_host_panics() {
+    // A Go panic in the host implementation crossing the cgo export into Rust
+    // is a fatal runtime crash — every generated trampoline must carry a
+    // deferred recover() that logs and returns through the named return value.
+    let trait_type = make_trait_type(
+        "OcrBackend",
+        vec![
+            // fallible method: panic is marshaled through outError, status 1
+            make_trait_method("process", vec![], TypeRef::String, true),
+            // infallible primitive method: panic logs and returns the zero value
+            make_trait_method(
+                "count_tokens",
+                vec![],
+                TypeRef::Primitive(alef::core::ir::PrimitiveType::Usize),
+                false,
+            ),
+        ],
+    );
+    let bridge_cfg = TraitBridgeConfig {
+        trait_name: "OcrBackend".to_string(),
+        super_trait: None,
+        registry_getter: Some("my_lib::get_registry".to_string()),
+        register_fn: Some("register_ocr_backend".to_string()),
+        unregister_fn: None,
+        clear_fn: None,
+        type_alias: None,
+        param_name: None,
+        register_extra_args: None,
+        exclude_languages: Vec::new(),
+        ffi_skip_methods: Vec::new(),
+        bind_via: alef::core::config::BridgeBinding::FunctionParam,
+        options_type: None,
+        options_field: None,
+        context_type: None,
+        result_type: None,
+    };
+    let config = make_config_with_bridges(vec![bridge_cfg]);
+    let api = make_api_with_type(trait_type);
+
+    let code = gen_trait_bridges_file(&api, &config, "testlib", "krz", "test.h", "../ffi", "..", "testlib");
+
+    // Every trampoline body opens with a deferred recover.
+    assert!(
+        code.contains("defer func() {") && code.contains("if r := recover(); r != nil {"),
+        "trampolines must recover host panics:\n{code}"
+    );
+    // Fallible: panic text marshaled through outError with status 1.
+    assert!(
+        code.contains("host 'Process' panicked") && code.contains("*outError = C.CString(fmt.Sprint(r))"),
+        "fallible trampoline must marshal the panic through outError:\n{code}"
+    );
+    // Infallible: stderr log, zero-value named return.
+    assert!(
+        code.contains("host 'CountTokens' panicked; returning default"),
+        "infallible trampoline must log the panic and return the default:\n{code}"
+    );
+    // Named return so the deferred recover can set it.
+    assert!(
+        code.contains("(ret C.int32_t)") || code.contains("(ret C."),
+        "trampolines must use a named return for the recover path:\n{code}"
+    );
+    // Invalid-handle paths must not fabricate a value and must write outError
+    // (or log) instead of a bare status.
+    assert!(
+        code.contains("called with an invalid handle"),
+        "invalid-handle paths must log:\n{code}"
+    );
+    // Plugin lifecycle trampolines are covered too.
+    assert!(
+        code.contains("host 'Name' panicked"),
+        "plugin Name trampoline must recover:\n{code}"
+    );
+}

--- a/tests/backends_java_gen_bindings_test.rs
+++ b/tests/backends_java_gen_bindings_test.rs
@@ -4622,3 +4622,135 @@ fn java_untagged_wrapper_with_text_types_emits_text_method() {
         "must return empty string as fallback:\n{src}"
     );
 }
+
+#[test]
+fn trait_bridge_sync_infallible_primitive_uses_direct_value_convention() {
+    // A sync infallible usize-returning method's C vtable slot is
+    // `fn(user_data, text) -> usize` (ffi c_return_convention direct-value
+    // branch). The upcall stub and handler must match that ABI exactly:
+    // no outResult/outError params, primitive descriptor return.
+    let make_method = |name: &str, params: Vec<ParamDef>, ret: TypeRef| MethodDef {
+        name: name.to_string(),
+        params,
+        return_type: ret,
+        is_async: false,
+        is_static: false,
+        error_type: None,
+        doc: String::new(),
+        receiver: Some(ReceiverKind::Ref),
+        sanitized: false,
+        trait_source: None,
+        returns_ref: false,
+        returns_cow: false,
+        return_newtype_wrapper: None,
+        has_default_impl: false,
+        binding_excluded: false,
+        binding_exclusion_reason: None,
+        version: Default::default(),
+    };
+    let text_param = ParamDef {
+        name: "text".to_string(),
+        ty: TypeRef::String,
+        optional: false,
+        default: None,
+        sanitized: false,
+        typed_default: None,
+        is_ref: true,
+        is_mut: false,
+        newtype_wrapper: None,
+        original_type: None,
+        map_is_ahash: false,
+        map_key_is_cow: false,
+        vec_inner_is_ref: false,
+        map_is_btree: false,
+        core_wrapper: alef::core::ir::CoreWrapper::None,
+    };
+    let tokenizer = TypeDef {
+        name: "Renderer".to_string(),
+        rust_path: "test_lib::Renderer".to_string(),
+        original_rust_path: String::new(),
+        fields: vec![],
+        methods: vec![
+            make_method(
+                "count_tokens",
+                vec![text_param],
+                TypeRef::Primitive(PrimitiveType::Usize),
+            ),
+            make_method("reset", vec![], TypeRef::Unit),
+        ],
+        is_opaque: true,
+        is_clone: false,
+        is_copy: false,
+        doc: String::new(),
+        cfg: None,
+        is_trait: true,
+        has_default: false,
+        has_stripped_cfg_fields: false,
+        is_return_type: false,
+        serde_rename_all: None,
+        has_serde: false,
+        super_traits: vec![],
+        binding_excluded: false,
+        binding_exclusion_reason: None,
+        is_variant_wrapper: false,
+        has_lifetime_params: false,
+        has_private_fields: false,
+        version: Default::default(),
+    };
+    let api = ApiSurface {
+        crate_name: "test_lib".to_string(),
+        version: "0.1.0".to_string(),
+        types: vec![tokenizer],
+        functions: vec![],
+        enums: vec![],
+        errors: vec![],
+        excluded_type_paths: Default::default(),
+        excluded_trait_names: Default::default(),
+        services: vec![],
+        handler_contracts: vec![],
+        unsupported_public_items: Vec::new(),
+    };
+
+    let files = JavaBackend
+        .generate_bindings(&api, &make_test_config_with_trait_bridge("com.example"))
+        .unwrap();
+    let bridge = files
+        .iter()
+        .find(|f| f.path.file_name().and_then(|n| n.to_str()) == Some("RendererBridge.java"))
+        .expect("RendererBridge.java")
+        .content
+        .as_str();
+
+    // Stub: long return, exactly userData + text params — no outResult/outError pair.
+    assert!(
+        bridge.contains("MethodType.methodType(long.class, MemorySegment.class, MemorySegment.class)"),
+        "direct-value stub must bind (userData, text) -> long: {bridge}"
+    );
+    assert!(
+        bridge.contains("FunctionDescriptor.of(ValueLayout.JAVA_LONG, ValueLayout.ADDRESS, ValueLayout.ADDRESS)"),
+        "direct-value descriptor must be JAVA_LONG(ADDRESS, ADDRESS): {bridge}"
+    );
+    // Handler: primitive return, no out-pointers, logged catch with a default.
+    assert!(
+        bridge.contains("private long handleCountTokens(MemorySegment userData, MemorySegment text_in)"),
+        "direct-value handler must return long with no out params: {bridge}"
+    );
+    assert!(
+        bridge.contains("host 'count_tokens' threw") && bridge.contains("return 0L;"),
+        "direct-value handler must log the host exception and return the default: {bridge}"
+    );
+    // Unit method: void stub via ofVoid, void handler.
+    assert!(
+        bridge.contains("FunctionDescriptor.ofVoid(ValueLayout.ADDRESS)"),
+        "infallible unit stub must use ofVoid with only userData: {bridge}"
+    );
+    assert!(
+        bridge.contains("private void handleReset(MemorySegment userData)"),
+        "infallible unit handler must be void with no out params: {bridge}"
+    );
+    // The JSON convention must not leak into these methods.
+    assert!(
+        !bridge.contains("private int handleCountTokens"),
+        "count_tokens must not use the int-status JSON convention: {bridge}"
+    );
+}

--- a/tests/backends_java_gen_bindings_test.rs
+++ b/tests/backends_java_gen_bindings_test.rs
@@ -4677,6 +4677,10 @@ fn trait_bridge_sync_infallible_primitive_uses_direct_value_convention() {
                 TypeRef::Primitive(PrimitiveType::Usize),
             ),
             make_method("reset", vec![], TypeRef::Unit),
+            // Round-2 catch-all shapes: infallible Path carries out_result but
+            // NOT out_error; infallible Bytes carries neither pointer.
+            make_method("cache_dir", vec![], TypeRef::Path),
+            make_method("raw_state", vec![], TypeRef::Bytes),
         ],
         is_opaque: true,
         is_clone: false,
@@ -4752,5 +4756,24 @@ fn trait_bridge_sync_infallible_primitive_uses_direct_value_convention() {
     assert!(
         !bridge.contains("private int handleCountTokens"),
         "count_tokens must not use the int-status JSON convention: {bridge}"
+    );
+    // Infallible Path: outResult but NO outError — the catch logs instead of
+    // writing a pointer the slot doesn't carry.
+    assert!(
+        bridge.contains("private int handleCacheDir(MemorySegment userData, MemorySegment outResult)"),
+        "infallible Path handler must carry outResult only: {bridge}"
+    );
+    assert!(
+        !bridge.contains("handleCacheDir(MemorySegment userData, MemorySegment outResult, MemorySegment outError)"),
+        "infallible Path slot has no outError on the C ABI: {bridge}"
+    );
+    assert!(
+        bridge.contains("host 'cache_dir' threw"),
+        "infallible Path catch must log instead of writeError: {bridge}"
+    );
+    // Infallible Bytes: neither pointer — no value channel exists on the C ABI.
+    assert!(
+        bridge.contains("private int handleRawState(MemorySegment userData)"),
+        "infallible Bytes handler must carry no out-pointers: {bridge}"
     );
 }

--- a/tests/backends_pyo3_gen_bindings/trait_bridge_methods.rs
+++ b/tests/backends_pyo3_gen_bindings/trait_bridge_methods.rs
@@ -29,8 +29,12 @@ fn test_gen_sync_method_body_unit_return_no_error() {
         "should resolve the host method by name and invoke it via the caller's contextvars context"
     );
     assert!(
-        body.contains("unwrap_or(())"),
-        "unit return without error should use unwrap_or(())"
+        body.contains("unwrap_or_else(|e|"),
+        "unit return without error should log and discard via unwrap_or_else"
+    );
+    assert!(
+        body.contains("eprintln!") && body.contains("host 'tick' raised; ignoring"),
+        "swallowed host exception should be logged with the method name"
     );
 }
 
@@ -63,8 +67,12 @@ fn test_gen_sync_method_body_string_return_no_error() {
     );
     assert!(body.contains("extract::<String>()"), "should extract String return");
     assert!(
-        body.contains("unwrap_or_default()"),
-        "infallible string return should use unwrap_or_default"
+        body.contains("unwrap_or_else(|e|") && body.contains("Default::default()"),
+        "infallible string return should log and substitute the default via unwrap_or_else"
+    );
+    assert!(
+        body.contains("eprintln!") && body.contains("host 'name' raised; returning default"),
+        "swallowed host exception should be logged with the method name"
     );
 }
 


### PR DESCRIPTION
Fixes #176.

## What this changes

Sync **infallible** trait-bridge methods (no error type in the Rust signature — `count_tokens(&self, text: &str) -> usize`, `Plugin::name()`, …) have no channel for a host-language failure. An audit of every backend found three failure classes on that surface; this PR fixes all of them.

### 1. Silent swallow → log-before-default

A raised/thrown host callback became `Default::default()` (0, "", empty) with no trace — indistinguishable from a real result. Concrete case: a bridged `count_tokens` that raises mid-run yields `0`, and a zero chunk size reads as "fits any budget" to a text splitter.

Every generated shim now logs the wrapper, method, and error before substituting the default (or discarding, for unit returns):

- **pyo3, napi, magnus, php, jni, rustler, extendr** — Rust-shim templates (`eprintln!`). jni additionally stops discarding the error text the Kotlin/Java dispatcher already marshals in its `{"err": …}` envelope. magnus's shared return-conversion template also covers its async body. rustler logs parse-failure and closed-reply-channel distinctly; host raises stay brief because the Elixir bridge already `Logger.error`s them.
- **wasm** — `console.error` reached via `js-sys` `Reflect` (generated wasm crates carry no `web-sys` dependency), so it works in browsers and Node.
- **csharp** — the primitive-return adapter's `catch (Exception) { return 0; }` now binds the exception and writes it to `Console.Error`.
- **ffi** — null-vtable-slot and null-out_result edge defaults log before defaulting.

### 2. Crash guards

- **go**: generated cgo trampolines had no `recover()` — a host panic crossing the cgo export into Rust was a fatal runtime crash. Every trampoline (trait methods and the four plugin lifecycle slots, whose `cgo.Handle.Value()` itself panics on a stale handle) now recovers, logs to stderr, and returns the zero value; fallible slots marshal the panic text through `outError`. The invalid-handle path no longer returns `1` — a fabricated value for value-returning slots.
- **dart**: the block_on shim's `.join().expect("thread panicked")` aborted the calling core thread; infallible methods now log and return the default. Fallible methods keep their existing behavior.

### 3. java FFM ABI mismatch (broken on every call, not just on exceptions)

The C vtable uses a direct-value convention for sync infallible simple returns: `fn(user_data, params...) -> <primitive>`, no out-pointers (`ffi::trait_bridge::c_return_convention`). The java generator emitted every upcall stub with the JSON convention — `(userData, params, outResult, outError) -> int` — so the stub read garbage registers as addresses (wild write on `outResult.set`) and Rust read the `0/1` status code as the return value. Stubs, `FunctionDescriptor`s, `MethodType`s, and handlers now implement the direct-value convention (mirroring the predicate in `c_return_convention`, integer layouts promoted to `JAVA_LONG` per the existing JBR-Win64 note), with a logged catch returning the default. C#'s delegate for the same slot was already correct and served as the model.

### Not affected

swift (non-throwing protocol, infallible at compile time), zig (non-error-union fn enforced at compile time), c (no exception mechanism), async methods (chains surface errors), and sync methods with a declared error type (`.map_err` branch).

## Verification

Full `cargo test` suite green (lib + all backend integration binaries, including the go/dart snapshot suites); the two pyo3 tests that pinned the old swallowed output now assert the logged form; dart's `emit_trait_bridge_method` signature change updated its two tests. Verified end-to-end against a consumer regeneration (kreuzberg + a sync `TokenizerBackend { count_tokens }` bridge): the regenerated pyo3/napi/php/wasm/jni/magnus/rustler/ffi shims, go trampolines, csharp adapter, and java bridge all carry the fixes, and the pyo3 path was exercised live from Python — a raising backend now logs the exception where it previously fabricated a zero count silently.
