### PR TITLE
fix(codegen): make generated binding→core conversions survive additive core fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **codegen**: generated binding→core struct conversions now survive additive core
+  changes. Every public-field `From<Binding> for Core` literal (and the lossy
+  method-body and mirror-crate constructor literals in the magnus, php, dart, and
+  swift backends) ends with `..Default::default()` whenever the core type
+  implements `Default` — previously the trailer was emitted only when a field was
+  skipped at generation time. A field added to a core config struct after
+  generation now falls back to its core default instead of breaking every
+  generated binding except napi with `E0063: missing field`, until the bindings
+  are regenerated. Currently-mapped fields are still assigned explicitly, so
+  existing conversions behave identically. `CODEGEN_FORMAT_VERSION` is bumped to
+  `2` so `alef verify` re-stamps existing bindings with the forward-compatible
+  literals.
+
 ## [0.34.0] - 2026-07-07
 
 ### Fixed

--- a/src/backends/dart/gen_rust_crate/mirror_conversions.rs
+++ b/src/backends/dart/gen_rust_crate/mirror_conversions.rs
@@ -500,18 +500,13 @@ pub(super) fn emit_from_mirror_to_core_struct(out: &mut String, ty: &TypeDef, so
         return;
     }
 
-    // The generated literal ends with `..Default::default()` whenever some core
-    // fields are intentionally omitted from the explicit field list AND the core
+    // The generated literal ends with `..Default::default()` whenever the core
     // type derives Default (the spread itself requires Default — otherwise E0277).
-    // Fields are omitted in two cases, both of which need the spread to fill them:
-    //   1. cfg-gated fields stripped from the IR (`has_stripped_cfg_fields`);
-    //   2. binding-excluded (`alef(skip)`) fields, which are skipped from the
-    //      literal in the `has_default` branch below so the core Default supplies
-    //      them (e.g. `SsrfPolicy::scheme_allowlist`/`allowlist`).
-    // Gating only on (1) left binding-excluded-only types (no cfg-stripped fields)
-    // with neither the field nor a spread — a hard E0063. Cover both cases.
-    let omits_core_fields = ty.has_stripped_cfg_fields || ty.fields.iter().any(|field| field.binding_excluded);
-    let needs_default_spread = omits_core_fields && ty.has_default;
+    // The spread fills cfg-gated fields stripped from the IR and binding-excluded
+    // (`alef(skip)`) fields skipped in the `has_default` branch below, and it keeps
+    // the literal compiling (E0063) when an additive field lands on the core
+    // struct after generation.
+    let needs_default_spread = ty.has_default;
     // clippy flags the spread as `needless_update` when the field list looks
     // complete from the mirror's perspective; silence it only when the spread is
     // actually emitted, otherwise the annotation is dead (unused_attributes).
@@ -577,10 +572,10 @@ pub(super) fn emit_from_mirror_to_core_struct(out: &mut String, ty: &TypeDef, so
         }
     }
 
-    // Emit ..Default::default() when core fields were omitted from the literal
-    // (cfg-stripped or binding-excluded) and the core type derives Default — see
-    // `needs_default_spread` above. Without Default the spread would E0277; such a
-    // type is unconstructible from the mirror and surfaces a diagnostic E0063.
+    // Emit ..Default::default() whenever the core type derives Default — see
+    // `needs_default_spread` above. Without Default the spread would E0277; a
+    // no-Default type with omitted core fields is unconstructible from the
+    // mirror and surfaces a diagnostic E0063.
     if needs_default_spread {
         out.push_str("            ..Default::default()\n");
     }

--- a/src/backends/dart/gen_rust_crate/mirror_conversions_tests.rs
+++ b/src/backends/dart/gen_rust_crate/mirror_conversions_tests.rs
@@ -86,13 +86,20 @@ fn mirror_to_core_binding_excluded_without_default_emits_explicit_only() {
 }
 
 #[test]
-fn mirror_to_core_no_excluded_no_spread() {
+fn mirror_to_core_fully_mirrored_with_default_emits_spread() {
+    // Forward-compatibility: a has_default core type with every field mirrored
+    // must still get the spread trailer, so an additive core field falls back
+    // to its default instead of failing E0063 until the bindings are regenerated.
     let ty = typ("Plain", true, false, vec![field("name", false), field("value", false)]);
     let mut out = String::new();
     emit_from_mirror_to_core_struct(&mut out, &ty, "source");
 
     assert!(
-        !out.contains("..Default::default()"),
-        "spread must not appear when there are no stripped cfg fields; got:\n{out}"
+        out.contains("..Default::default()"),
+        "has_default core type must always get the spread trailer; got:\n{out}"
+    );
+    assert!(
+        out.contains("#[allow(clippy::needless_update)]"),
+        "needless_update allow should accompany the emitted spread; got:\n{out}"
     );
 }

--- a/src/backends/php/gen_bindings/helpers/enum_defaults.rs
+++ b/src/backends/php/gen_bindings/helpers/enum_defaults.rs
@@ -81,7 +81,6 @@ pub(crate) fn gen_enum_tainted_from_binding_to_core(
         }
     }
 
-    let has_binding_excluded_fields = typ.fields.iter().any(|f| f.binding_excluded);
     // Collect `(core_field, rhs_expr)` pairs, then emit either a struct literal or — for core
     // types whose private (`pub(crate)`) fields forbid struct-literal construction — a
     // `Default`-seeded builder via the shared construction strategy (the same one the
@@ -273,12 +272,20 @@ pub(crate) fn gen_enum_tainted_from_binding_to_core(
     }
 
     // Struct-literal path for types whose fields are all public.
+    //
+    // Emit the ..Default::default() trailer (and its needless_update allow) for
+    // every has_default core type: it fills cfg-stripped and binding-excluded
+    // fields with the core's Default, and it keeps the literal compiling (E0063)
+    // when an additive field lands on the core struct after generation. Without
+    // Default the spread fails E0277; for binding-excluded fields the loop above
+    // already pushed explicit `field: Default::default()` assignments then.
+    let emit_default_spread = typ.has_default;
     let mut out = crate::backends::php::template_env::render(
         "php_impl_from_begin.jinja",
         context! {
             binding_type => &typ.name,
             core_type => &core_path,
-            has_stripped_cfg_fields => typ.has_stripped_cfg_fields,
+            emit_spread => emit_default_spread,
         },
     );
     for &(field_name, ref field_expr) in &fields {
@@ -290,15 +297,10 @@ pub(crate) fn gen_enum_tainted_from_binding_to_core(
             },
         ));
     }
-    // Only emit the trailing `..Default::default()` spread when the core type
-    // derives Default — otherwise E0277 blocks compilation. For binding-excluded
-    // fields the loop above already pushed explicit `field: Default::default()`
-    // assignments when `!typ.has_default`.
-    let emit_default_spread = typ.has_default && (typ.has_stripped_cfg_fields || has_binding_excluded_fields);
     out.push_str(&crate::backends::php::template_env::render(
         "php_impl_from_end.jinja",
         context! {
-            has_stripped_cfg_fields => emit_default_spread,
+            emit_spread => emit_default_spread,
         },
     ));
     out
@@ -532,7 +534,10 @@ mod tests {
     }
 
     #[test]
-    fn enum_tainted_no_excluded_fields_no_spread() {
+    fn enum_tainted_fully_mirrored_with_default_still_emits_spread() {
+        // Forward-compatibility: a has_default core type with every field mirrored
+        // must still get the spread trailer, so an additive core field falls back
+        // to its default instead of failing E0063 until the bindings are regenerated.
         let typ = typ(
             "PlainEnumTainted",
             true,
@@ -550,8 +555,37 @@ mod tests {
         );
 
         assert!(
+            out.contains("..Default::default()"),
+            "has_default core type must always get the spread trailer; got:\n{out}"
+        );
+        assert!(
+            out.contains("#[allow(clippy::needless_update)]"),
+            "the spread over a fully-mirrored literal needs the needless_update allow; got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn enum_tainted_fully_mirrored_without_default_keeps_exhaustive_literal() {
+        let typ = typ(
+            "NoDefaultPlain",
+            false,
+            vec![field("name", false), field("value", false)],
+        );
+        let cfg = ConversionConfig::default();
+        let out = gen_enum_tainted_from_binding_to_core(
+            &typ,
+            "crate",
+            &AHashSet::new(),
+            &AHashSet::new(),
+            &cfg,
+            &[],
+            &AHashSet::new(),
+        );
+
+        assert!(
             !out.contains("..Default::default()"),
-            "spread must not appear when there are no excluded/stripped fields; got:\n{out}"
+            "the spread trailer must not be emitted when the core type has no Default \
+             impl — it would fail to compile (E0277); got:\n{out}"
         );
     }
 }

--- a/src/backends/php/gen_bindings/helpers/struct_conversion.rs
+++ b/src/backends/php/gen_bindings/helpers/struct_conversion.rs
@@ -100,10 +100,9 @@ pub(crate) fn gen_php_lossy_binding_to_core_fields(
         "php_lossy_binding_struct_begin.jinja",
         context! {
             core_type => &core_path,
-            has_stripped_cfg_fields => typ.has_stripped_cfg_fields,
+            emit_spread => typ.has_default,
         },
     );
-    let has_binding_excluded_fields = typ.fields.iter().any(|f| f.binding_excluded);
     for field in &typ.fields {
         if field.binding_excluded {
             if !typ.has_default {
@@ -300,13 +299,14 @@ pub(crate) fn gen_php_lossy_binding_to_core_fields(
             ));
         }
     }
-    // Use ..Default::default() to fill cfg-gated fields stripped from the IR,
-    // and binding-excluded fields (alef(skip)) so they pick up the core's Default,
-    // including custom Default impls that depend on runtime configuration. Only
-    // emit when the core type derives Default — otherwise the spread fails E0277.
-    // For binding-excluded fields the loop above already emitted explicit
-    // `field: Default::default()` assignments when `!typ.has_default`.
-    if typ.has_default && (typ.has_stripped_cfg_fields || has_binding_excluded_fields) {
+    // Emit the ..Default::default() trailer for every has_default core type: it
+    // fills cfg-gated fields stripped from the IR and binding-excluded fields
+    // (alef(skip)) with the core's Default — including custom Default impls that
+    // depend on runtime configuration — and it keeps the literal compiling
+    // (E0063) when an additive field lands on the core struct after generation.
+    // Without Default the spread fails E0277; for binding-excluded fields the
+    // loop above already emitted explicit `field: Default::default()` then.
+    if typ.has_default {
         out.push_str(&crate::backends::php::template_env::render(
             "php_default_update.jinja",
             minijinja::Value::default(),
@@ -389,13 +389,20 @@ mod tests {
     }
 
     #[test]
-    fn no_excluded_fields_no_spread() {
+    fn fully_mirrored_with_default_still_emits_spread() {
+        // Forward-compatibility: a has_default core type with every field mirrored
+        // must still get the spread trailer, so an additive core field falls back
+        // to its default instead of failing E0063 until the bindings are regenerated.
         let typ = typ("Plain", true, vec![field("name", false), field("value", false)]);
         let out = gen_php_lossy_binding_to_core_fields(&typ, "crate", &AHashSet::new(), &AHashSet::new(), &[]);
 
         assert!(
-            !out.contains("..Default::default()"),
-            "spread must not appear when there are no excluded/stripped fields; got:\n{out}"
+            out.contains("..Default::default()"),
+            "has_default core type must always get the spread trailer; got:\n{out}"
+        );
+        assert!(
+            out.contains("#[allow(clippy::needless_update)]"),
+            "the spread over a fully-mirrored literal needs the needless_update allow; got:\n{out}"
         );
         assert!(out.contains("name:"), "name field should appear; got:\n{out}");
         assert!(out.contains("value:"), "value field should appear; got:\n{out}");

--- a/src/backends/php/templates/php_impl_from_begin.jinja
+++ b/src/backends/php/templates/php_impl_from_begin.jinja
@@ -1,4 +1,4 @@
-{%- if has_stripped_cfg_fields %}
+{%- if emit_spread %}
 #[allow(clippy::needless_update)]
 {%- endif %}
 #[allow(clippy::useless_conversion)]

--- a/src/backends/php/templates/php_impl_from_end.jinja
+++ b/src/backends/php/templates/php_impl_from_end.jinja
@@ -1,4 +1,4 @@
-{%- if has_stripped_cfg_fields %}
+{%- if emit_spread %}
             ..Default::default()
 {%- endif %}
         }

--- a/src/backends/php/templates/php_lossy_binding_struct_begin.jinja
+++ b/src/backends/php/templates/php_lossy_binding_struct_begin.jinja
@@ -1,2 +1,2 @@
-{% if has_stripped_cfg_fields %}#[allow(clippy::needless_update)]
-{% endif %}{% if has_stripped_cfg_fields %}        {% endif %}let core_self = {{ core_type }} {
+{% if emit_spread %}#[allow(clippy::needless_update)]
+{% endif %}{% if emit_spread %}        {% endif %}let core_self = {{ core_type }} {

--- a/src/backends/swift/gen_rust_crate/wrappers/constructors.rs
+++ b/src/backends/swift/gen_rust_crate/wrappers/constructors.rs
@@ -107,6 +107,14 @@ pub(crate) fn emit_type_wrapper(
             // Omit the constructor entirely — swift-bridge will not expose `init()` for
             // this type, which is correct: the host language can't construct it anyway.
         } else {
+            // The direct struct literal below ends with `..Default::default()`
+            // when the core type impls Default, so an additive core field falls
+            // back to its default instead of failing E0063 until the bindings
+            // are regenerated. Clippy flags the spread on a fully-mirrored
+            // literal as needless_update — allow it on the constructor.
+            if !needs_default_construction && ty.has_default {
+                out.push_str("    #[allow(clippy::needless_update)]\n");
+            }
             out.push_str(&crate::backends::swift::template_env::render(
                 "fn_new_signature.jinja",
                 minijinja::context! {
@@ -145,6 +153,9 @@ pub(crate) fn emit_type_wrapper(
                 for init in &field_inits {
                     out.push_str(init);
                     out.push_str(",\n");
+                }
+                if ty.has_default {
+                    out.push_str("            ..Default::default()\n");
                 }
                 out.push_str("        })\n");
             }
@@ -320,5 +331,81 @@ mod tests {
         assert!(!output.contains("field_b: String"));
         // The constructor SHOULD include field_a
         assert!(output.contains("field_a: u32"));
+    }
+
+    fn primitive_field(name: &str) -> FieldDef {
+        FieldDef {
+            name: name.to_string(),
+            ty: TypeRef::Primitive(crate::core::ir::PrimitiveType::U32),
+            optional: false,
+            ..Default::default()
+        }
+    }
+
+    fn primitive_only_type(has_default: bool) -> crate::core::ir::TypeDef {
+        crate::core::ir::TypeDef {
+            name: "SampleLimits".to_string(),
+            rust_path: "test::SampleLimits".to_string(),
+            fields: vec![primitive_field("depth"), primitive_field("width")],
+            is_clone: true,
+            has_default,
+            ..Default::default()
+        }
+    }
+
+    fn emit_wrapper(ty: &crate::core::ir::TypeDef) -> String {
+        emit_type_wrapper(
+            ty,
+            "test_crate",
+            &std::collections::HashMap::new(),
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+        )
+    }
+
+    /// Forward-compatibility: the direct struct-literal constructor for a
+    /// has_default core type must end with `..Default::default()`, so an
+    /// additive core field falls back to its default instead of failing E0063
+    /// until the bindings are regenerated.
+    #[test]
+    fn wrapper_constructor_direct_literal_with_default_spreads() {
+        let output = emit_wrapper(&primitive_only_type(true));
+
+        assert!(
+            output.contains("..Default::default()"),
+            "has_default core type must get the spread trailer in the direct-literal \
+             constructor; got:\n{output}"
+        );
+        assert!(
+            output.contains("#[allow(clippy::needless_update)]"),
+            "the spread over a fully-mirrored literal needs the needless_update allow; \
+             got:\n{output}"
+        );
+    }
+
+    /// Companion: without a core `Default` impl the spread cannot compile (E0277) —
+    /// the exhaustive literal must stay as-is.
+    #[test]
+    fn wrapper_constructor_direct_literal_without_default_keeps_exhaustive_literal() {
+        let output = emit_wrapper(&primitive_only_type(false));
+
+        assert!(
+            output.contains("pub fn new("),
+            "primitive-only DTOs keep their direct constructor regardless of Default; \
+             got:\n{output}"
+        );
+        assert!(
+            !output.contains("..Default::default()"),
+            "the spread trailer must not be emitted when the core type has no Default \
+             impl; got:\n{output}"
+        );
+        assert!(
+            !output.contains("#[allow(clippy::needless_update)]"),
+            "needless_update allow must not be emitted when no spread; got:\n{output}"
+        );
     }
 }

--- a/src/codegen/conversions/binding_to_core/render.rs
+++ b/src/codegen/conversions/binding_to_core/render.rs
@@ -236,17 +236,16 @@ pub fn gen_from_binding_to_core_cfg(typ: &TypeDef, core_import: &str, config: &C
     // Pre-compute all fields
     let mut fields = Vec::new();
     let mut statements = Vec::new();
-    // Track whether any binding-excluded field was skipped — when so, force the
-    // `..Default::default()` trailer so the core type's Default impl fills those
-    // fields in (preserves invariants like `SsrfPolicy::from_env`, which an
-    // explicit field-level `Default::default()` on a sub-type would bypass).
+    // Binding-excluded fields are skipped from the literal; the
+    // `..Default::default()` trailer fills them from the core type's Default impl
+    // (preserves invariants like `SsrfPolicy::from_env`, which an explicit
+    // field-level `Default::default()` on a sub-type would bypass).
     //
     // Exception: when the core type does not implement Default, the spread
     // trailer would fail to compile. In that case, fall back to emitting
     // per-field `Default::default()` for each binding-excluded field — there
     // is no core Default to bypass.
     let core_has_default = typ.has_default;
-    let mut skipped_binding_excluded = false;
 
     for field in &typ.fields {
         if field.binding_excluded {
@@ -266,7 +265,6 @@ pub fn gen_from_binding_to_core_cfg(typ: &TypeDef, core_import: &str, config: &C
                 fields.push(format!("{}: Default::default()", field.name));
                 continue;
             }
-            skipped_binding_excluded = true;
             continue;
         }
         // Cfg-gated fields: emit the assignment with `#[cfg(...)]` so it only applies when
@@ -319,9 +317,13 @@ pub fn gen_from_binding_to_core_cfg(typ: &TypeDef, core_import: &str, config: &C
         }
     }
 
-    // Note: ..Default::default() for cfg-gated fields is emitted by the template
-    // via the has_stripped_cfg_fields context variable — do not push it here.
-    let emit_trailer = typ.has_stripped_cfg_fields || skipped_binding_excluded;
+    // Note: the ..Default::default() trailer is emitted by the template via the
+    // has_stripped_cfg_fields context variable — do not push it here. Every
+    // has_default core type gets the trailer, even when all current fields are
+    // mirrored: an additive core field then falls back to its default instead of
+    // breaking the generated impl with E0063 until the bindings are regenerated.
+    // The trailer also fills any binding-excluded fields skipped above.
+    let emit_trailer = typ.has_stripped_cfg_fields || core_has_default;
 
     crate::codegen::template_env::render(
         "conversions/binding_to_core_impl",

--- a/src/codegen/conversions/binding_to_core/tests.rs
+++ b/src/codegen/conversions/binding_to_core/tests.rs
@@ -376,3 +376,49 @@ fn private_fields_type_without_default_emits_compile_error() {
         "must not emit a struct-literal field for a type with private fields; got:\n{out}"
     );
 }
+
+/// Forward-compatibility: a fully-mirrored core type that implements `Default`
+/// (every field present in the binding, none binding-excluded, no cfg-stripping)
+/// must still get the `..Default::default()` trailer. Without it the exhaustive
+/// literal stops compiling with E0063 the moment an additive field lands on the
+/// core struct, until the bindings are regenerated.
+#[test]
+fn fully_mirrored_type_with_default_emits_spread_trailer() {
+    let typ = type_with_field(string_field("content"));
+
+    let out = gen_from_binding_to_core(&typ, "crate");
+
+    assert!(
+        out.contains("content: val.content"),
+        "mirrored fields must still be assigned explicitly; got:\n{out}"
+    );
+    assert!(
+        out.contains("..Default::default()"),
+        "a has_default core type must get the spread trailer so an additive core \
+         field falls back to its default instead of breaking the impl; got:\n{out}"
+    );
+    assert!(
+        out.contains("#[allow(clippy::needless_update)]"),
+        "the spread over a fully-mirrored literal needs the needless_update allow; got:\n{out}"
+    );
+}
+
+/// Companion: a fully-mirrored core type WITHOUT `Default` cannot take the spread
+/// trailer (E0277) — the exhaustive literal must stay as-is.
+#[test]
+fn fully_mirrored_type_without_default_keeps_exhaustive_literal() {
+    let mut typ = type_with_field(string_field("content"));
+    typ.has_default = false;
+
+    let out = gen_from_binding_to_core(&typ, "crate");
+
+    assert!(
+        out.contains("content: val.content"),
+        "mirrored fields must be assigned explicitly; got:\n{out}"
+    );
+    assert!(
+        !out.contains("..Default::default()"),
+        "the spread trailer must not be emitted when the core type has no Default \
+         impl — it would fail to compile (E0277); got:\n{out}"
+    );
+}

--- a/src/codegen/generators/binding_helpers/lossy_fields.rs
+++ b/src/codegen/generators/binding_helpers/lossy_fields.rs
@@ -80,24 +80,23 @@ fn gen_lossy_binding_to_core_fields_inner(
         return format!("let {mut_kw}core_self = {core_path}::from(self.clone());\n        ");
     }
 
-    // When has_stripped_cfg_fields is true we emit ..Default::default() at the end of the
-    // struct literal to fill cfg-gated fields that were stripped from the binding IR.
-    // Suppress clippy::needless_update because the fields only exist when the corresponding
-    // feature is enabled — without the feature, clippy thinks the spread is redundant.
-    let allow = if typ.has_stripped_cfg_fields {
+    // The struct literal ends with ..Default::default() whenever the trailer can
+    // compile (see the emission condition at the bottom). Suppress
+    // clippy::needless_update because the trailer is intentionally emitted even
+    // when the field list looks complete — clippy would flag the spread as
+    // redundant on a fully-mirrored literal.
+    let allow = if typ.has_stripped_cfg_fields || typ.has_default {
         "#[allow(clippy::needless_update)]\n        "
     } else {
         ""
     };
     let mut out = format!("{allow}let {mut_kw}core_self = {core_path} {{\n");
-    // Track whether any binding-excluded field was skipped (vs emitted per-field).
-    // Only when at least one is skipped do we need the `..Default::default()` trailer.
-    // When the core type does NOT implement Default, the trailer would not compile
-    // (E0277), so emit `field: Default::default()` per-field instead — there is no
-    // bespoke core Default whose semantics we could be bypassing. Mirrors the
-    // parallel fix in `codegen/conversions/binding_to_core/render.rs` (096eb298c).
+    // When the core type does NOT implement Default, the `..Default::default()`
+    // trailer would not compile (E0277), so emit `field: Default::default()`
+    // per-field for binding-excluded fields instead — there is no bespoke core
+    // Default whose semantics we could be bypassing. Mirrors the parallel logic
+    // in `codegen/conversions/binding_to_core/render.rs`.
     let core_has_default = typ.has_default;
-    let mut skipped_binding_excluded = false;
     for field in &typ.fields {
         if field.binding_excluded {
             if !core_has_default {
@@ -119,7 +118,6 @@ fn gen_lossy_binding_to_core_fields_inner(
             // defaults that derive field values from environment or runtime configuration.
             // Emitting `<field>: Default::default()` would shadow that with the sub-type's
             // (often stricter) default value.
-            skipped_binding_excluded = true;
             continue;
         }
         // Skip cfg-gated fields — they are absent from the binding struct.
@@ -411,15 +409,15 @@ fn gen_lossy_binding_to_core_fields_inner(
         ));
         out.push('\n');
     }
-    // Use ..Default::default() to fill cfg-gated fields stripped from the IR,
-    // and binding-excluded fields (alef(skip)) so they pick up the core's Default.
-    // The binding-excluded trailer is only emitted when the core type impls Default
-    // (otherwise the per-field fallback above emits explicit `Default::default()`
-    // per skipped field); the cfg-stripped trailer is unconditional because the
-    // `#[cfg(...)]` gates make the spread a no-op when the feature is disabled
-    // and the gated paths rely on the core type being Default-constructible when
-    // the feature is enabled.
-    if typ.has_stripped_cfg_fields || (skipped_binding_excluded && typ.has_default) {
+    // Emit the ..Default::default() trailer for every has_default core type — it
+    // fills binding-excluded fields (alef(skip)) with the core's Default, and it
+    // keeps the literal compiling (E0063) when an additive field lands on the core
+    // struct after generation. Without Default the trailer would fail E0277, so
+    // the per-field fallback above covers binding-excluded fields instead; the
+    // cfg-stripped trailer stays unconditional because the `#[cfg(...)]` gates
+    // make the spread a no-op when the feature is disabled and the gated paths
+    // rely on the core type being Default-constructible when it is enabled.
+    if typ.has_stripped_cfg_fields || typ.has_default {
         out.push_str("            ..Default::default()\n");
     }
     out.push_str("        };\n        ");

--- a/src/core/template_versions.rs
+++ b/src/core/template_versions.rs
@@ -453,5 +453,5 @@ pub mod precommit {
     ///
     /// Do NOT increment for dependency version bumps, style fixes, or any
     /// change that does not affect `compute_inputs_hash` output.
-    pub const CODEGEN_FORMAT_VERSION: &str = "1";
+    pub const CODEGEN_FORMAT_VERSION: &str = "2";
 }

--- a/tests/codegen_integration/binding_helper_lossy.rs
+++ b/tests/codegen_integration/binding_helper_lossy.rs
@@ -710,3 +710,32 @@ fn test_gen_lossy_binding_to_core_fields_binding_excluded_with_default_uses_spre
          type has Default — would bypass bespoke Default semantics; got:\n{result}"
     );
 }
+
+#[test]
+fn test_gen_lossy_binding_to_core_fields_fully_mirrored_with_default_emits_spread() {
+    // Forward-compatibility: a has_default core type whose fields are all mirrored
+    // must still end the literal with `..Default::default()`, so an additive core
+    // field falls back to its default instead of breaking the generated method
+    // body with E0063 until the bindings are regenerated.
+    let mut typ = simple_type_def();
+    typ.has_default = true;
+
+    let result = binding_helpers::gen_lossy_binding_to_core_fields(
+        &typ,
+        "my_crate",
+        false,
+        &ahash::AHashSet::new(),
+        false,
+        false,
+        &[],
+    );
+
+    assert!(
+        result.contains("..Default::default()"),
+        "fully-mirrored has_default core type must get the spread trailer; got:\n{result}"
+    );
+    assert!(
+        result.contains("#[allow(clippy::needless_update)]"),
+        "the spread over a fully-mirrored literal needs the needless_update allow; got:\n{result}"
+    );
+}

--- a/tests/snapshots/backends_swift_snapshot_test__snapshot_intorust_bulk_nested__packages__swift__rust__src__lib.rs.snap
+++ b/tests/snapshots/backends_swift_snapshot_test__snapshot_intorust_bulk_nested__packages__swift__rust__src__lib.rs.snap
@@ -100,10 +100,12 @@ pub fn __alef_phantom_vec_process_result() -> Vec<ProcessResult> { Vec::new() }
 
 pub struct Span(pub demo::Span);
 impl Span {
+    #[allow(clippy::needless_update)]
     pub fn new(start_byte: usize, end_byte: usize) -> Span {
         Span(demo::Span {
             start_byte,
             end_byte,
+            ..Default::default()
         })
     }
     pub fn start_byte(&self) -> usize {

--- a/tests/snapshots/backends_swift_snapshot_test__snapshot_intorust_bulk_primitives__packages__swift__rust__src__lib.rs.snap
+++ b/tests/snapshots/backends_swift_snapshot_test__snapshot_intorust_bulk_primitives__packages__swift__rust__src__lib.rs.snap
@@ -73,10 +73,12 @@ pub fn __alef_phantom_vec_span() -> Vec<Span> { Vec::new() }
 
 pub struct Span(pub demo::Span);
 impl Span {
+    #[allow(clippy::needless_update)]
     pub fn new(start_byte: usize, end_byte: usize) -> Span {
         Span(demo::Span {
             start_byte,
             end_byte,
+            ..Default::default()
         })
     }
     pub fn start_byte(&self) -> usize {

--- a/tests/snapshots/backends_swift_snapshot_test__snapshot_trait_bridge_inbound_options_field__packages__swift__rust__src__lib.rs.snap
+++ b/tests/snapshots/backends_swift_snapshot_test__snapshot_trait_bridge_inbound_options_field__packages__swift__rust__src__lib.rs.snap
@@ -106,9 +106,11 @@ pub struct CallbackHandle(pub demo::callbacks::CallbackHandle);
 
 pub struct RenderOptions(pub demo::options::RenderOptions);
 impl RenderOptions {
+    #[allow(clippy::needless_update)]
     pub fn new(timeout_ms: u32) -> RenderOptions {
         RenderOptions(demo::options::RenderOptions {
             timeout_ms,
+            ..Default::default()
         })
     }
     pub fn timeout_ms(&self) -> u32 {


### PR DESCRIPTION
Fixes #179.

## What this changes

The binding→core `From` impl alef generates for a public-field config type was a fully exhaustive struct literal. The moment a field was added to the core struct — a purely additive, backward-compatible change — every generated binding except napi stopped compiling with `E0063: missing field` until a regen. napi was immune only because `optionalize_defaults` routes it through a `Default`-seeded builder.

Every struct-literal path that converts a binding value into a core type now ends with `..Default::default()` whenever the core type implements `Default` (previously only when a field was skipped at generation time), paired with `#[allow(clippy::needless_update)]`. The currently-mapped fields are still assigned explicitly, so existing conversions behave identically; a field added to the core after generation falls back to its core default instead of breaking the build. Types without a core `Default` keep the exhaustive literal — the spread cannot compile there (E0277).

**Before** (pyo3; the same shape in ruby, elixir, php, wasm, dart, extendr, and the swift bridge crate):

```rust
impl From<EmbeddingConfig> for core::EmbeddingConfig {
    fn from(val: EmbeddingConfig) -> Self {
        Self {
            model: val.model.into(),
            normalize: val.normalize,
            // ...every core field named — a new core field is E0063 until regen
        }
    }
}
```

**After**:

```rust
#[allow(clippy::needless_update)]
impl From<EmbeddingConfig> for core::EmbeddingConfig {
    fn from(val: EmbeddingConfig) -> Self {
        Self {
            model: val.model.into(),
            normalize: val.normalize,
            // ...
            ..Default::default() // a new core field keeps its default; still compiles
        }
    }
}
```

Covered emission paths:

- **shared `binding_to_core` render** — the `From` impls behind pyo3, extendr, rustler, wasm, magnus, and php
- **shared lossy method-body helper** — the `let core_self = Core { … }` literals in extendr/magnus/php instance methods
- **php** — the enum-bearing `From` generator (`enum_defaults`) and the php-local lossy literal
- **dart** — the mirror-crate `From<Mirror> for Core` impls
- **swift** — the direct struct-literal `new()` constructors in the generated bridge crate

napi (builder mode) and the private-field construction path already seed from `Default` and are unchanged.

`CODEGEN_FORMAT_VERSION` is bumped to `2` so `alef verify` reports existing bindings stale and consumers re-stamp them with the forward-compatible literals.

## Verification

Full `cargo test` suite green (4,234 lib tests plus all integration and snapshot binaries; three swift snapshots re-accepted with exactly the allow + spread lines added). `poly fmt` / `poly lint` (clippy, deny) clean. Verified end-to-end against a consumer regeneration (kreuzberg): `alef all` regenerates the pyo3, php, wasm, node, ruby, elixir, dart, and swift artifacts with the trailer on every `Default`-implementing config type, and a sweep of all eight generated crates found no remaining exhaustive binding→core literal for a `Default` core struct. The regenerated pyo3 and php crates compile and are clippy-clean.
