### PR TITLE
feat(wasm): support extra_dev_dependencies in the generated binding Cargo.toml

### DIFF
--- a/src/backends/wasm/gen_bindings/cargo.rs
+++ b/src/backends/wasm/gen_bindings/cargo.rs
@@ -129,6 +129,29 @@ pub(super) fn gen_cargo_toml(api: &ApiSurface, config: &ResolvedCrateConfig) -> 
         .collect::<Vec<_>>()
         .join("\n");
 
+    // Hand-written test files in the binding crate (e.g. `#[wasm_bindgen_test]`
+    // suites) need test-only dependencies the generated manifest must carry.
+    let mut dev_dep_lines: Vec<String> = config
+        .wasm
+        .as_ref()
+        .map(|c| c.extra_dev_dependencies.iter().collect::<Vec<_>>())
+        .unwrap_or_default()
+        .into_iter()
+        .map(|(name, value)| {
+            if let Some(v) = value.as_str() {
+                format!("{name} = \"{v}\"")
+            } else {
+                format!("{name} = {value}")
+            }
+        })
+        .collect();
+    dev_dep_lines.sort();
+    let dev_deps_section = if dev_dep_lines.is_empty() {
+        String::new()
+    } else {
+        format!("\n[dev-dependencies]\n{}\n", dev_dep_lines.join("\n"))
+    };
+
     format!(
         r#"{header}
 [package]
@@ -157,7 +180,7 @@ crate-type = ["cdylib"]
 
 {features_table}[dependencies]
 {deps_block}
-
+{dev_deps_section}
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = {{ version = "0.4", features = ["wasm_js"] }}
 getrandom_02 = {{ package = "getrandom", version = "0.2", features = ["js"] }}
@@ -171,6 +194,7 @@ getrandom_03 = {{ package = "getrandom", version = "0.3", features = ["wasm_js"]
         repository = repository,
         keywords_toml = keywords_toml,
         deps_block = deps_block,
+        dev_deps_section = dev_deps_section,
         features_table = features_table,
     )
 }

--- a/src/backends/wasm/gen_bindings/tests.rs
+++ b/src/backends/wasm/gen_bindings/tests.rs
@@ -269,3 +269,58 @@ fn test_visitor_field_substitution_in_post_process() {
         "Unreplaced visitor: Default::default() with 12 spaces still present"
     );
 }
+
+#[test]
+fn cargo_toml_emits_extra_dev_dependencies() {
+    let cfg: NewAlefConfig = toml::from_str(
+        r#"
+[workspace]
+languages = ["wasm"]
+[[crates]]
+name = "test-lib"
+sources = ["src/lib.rs"]
+[crates.wasm]
+[crates.wasm.extra_dev_dependencies]
+wasm-bindgen-test = "0.3"
+serde_json = { version = "1", features = ["preserve_order"] }
+"#,
+    )
+    .unwrap();
+    let config = cfg.resolve().unwrap().remove(0);
+    let api = ApiSurface {
+        crate_name: "test-lib".to_string(),
+        version: "0.1.0".to_string(),
+        types: vec![],
+        functions: vec![],
+        enums: vec![],
+        errors: vec![],
+        excluded_type_paths: ::std::collections::HashMap::new(),
+        excluded_trait_names: ::std::collections::HashSet::new(),
+        services: vec![],
+        handler_contracts: vec![],
+        unsupported_public_items: Vec::new(),
+    };
+
+    let cargo_toml = gen_cargo_toml(&api, &config);
+
+    assert!(
+        cargo_toml.contains("[dev-dependencies]"),
+        "expected a [dev-dependencies] section in:\n{cargo_toml}"
+    );
+    assert!(
+        cargo_toml.contains(r#"wasm-bindgen-test = "0.3""#),
+        "expected the string-valued dev dependency in:\n{cargo_toml}"
+    );
+    let parsed: toml::Value = toml::from_str(&cargo_toml).expect("generated Cargo.toml must be valid TOML");
+    let dev = parsed
+        .get("dev-dependencies")
+        .expect("dev-dependencies table must exist");
+    assert!(dev.get("serde_json").and_then(|v| v.get("features")).is_some());
+
+    // Without the config key, no section is emitted.
+    let plain = gen_cargo_toml(&api, &make_config());
+    assert!(
+        !plain.contains("[dev-dependencies]"),
+        "unexpected dev-deps in:\n{plain}"
+    );
+}

--- a/src/core/config/languages/wasm.rs
+++ b/src/core/config/languages/wasm.rs
@@ -31,6 +31,13 @@ pub struct WasmConfig {
     #[serde(default)]
     #[schemars(with = "HashMap<String, serde_json::Value>")]
     pub extra_dependencies: HashMap<String, toml::Value>,
+    /// Additional `[dev-dependencies]` entries for the generated WASM binding
+    /// crate's Cargo.toml. Declares test-only dependencies for hand-written
+    /// test files (e.g. `wasm-bindgen-test` for in-crate `#[wasm_bindgen_test]`
+    /// suites) without hand-editing the generated manifest.
+    #[serde(default)]
+    #[schemars(with = "HashMap<String, serde_json::Value>")]
+    pub extra_dev_dependencies: HashMap<String, toml::Value>,
     /// Per-field name remapping for this language. Key is `TypeName.field_name`, value is the
     /// desired binding field name. Applied after automatic keyword escaping.
     #[serde(default)]


### PR DESCRIPTION
Closes #181.

## Problem

The wasm backend supports hand-written modules in the binding crate through `custom_rust_modules`, but the generated Cargo.toml cannot carry `[dev-dependencies]`. Hand-written test files don't compile: an in-crate `#[wasm_bindgen_test]` suite needs `wasm-bindgen-test`, and the only routes were hand-editing a DO-NOT-EDIT manifest or shipping test-only crates as real dependencies through `extra_dependencies`.

In xberg-io/xberg#1259 this forced the contributed wasm-bindgen suites out of the crate and into the JS e2e harness.

## Solution

A new `[crates.wasm.extra_dev_dependencies]` table, mirroring the per-language `extra_dependencies`. When it is non-empty, the cargo generator emits a `[dev-dependencies]` section between `[dependencies]` and the target-specific block: sorted, string values quoted, structured values passed through.

An empty table emits nothing, so existing projects regenerate byte-identically.

## Verification

A unit test covers both value shapes and the empty-table case (`cargo test -p alef --lib backends::wasm::gen_bindings::tests`, 9 passed). `cargo clippy --lib --tests -- -D warnings` and `cargo fmt --check` are clean.
