### PR TITLE
fix(pyo3): widen numeric trait-bridge Protocol returns to Iterable

### DIFF
--- a/src/backends/pyo3/gen_stubs.rs
+++ b/src/backends/pyo3/gen_stubs.rs
@@ -331,11 +331,19 @@ pub fn gen_stubs(
     }
 
     let body_joined = body_lines.join("\n");
-    let used_typing: Vec<&str> = ["Any", "AsyncIterator", "Literal", "Protocol", "TypeAlias", "TypedDict"]
-        .iter()
-        .copied()
-        .filter(|name| contains_word(&body_joined, name))
-        .collect();
+    let used_typing: Vec<&str> = [
+        "Any",
+        "AsyncIterator",
+        "Iterable",
+        "Literal",
+        "Protocol",
+        "TypeAlias",
+        "TypedDict",
+    ]
+    .iter()
+    .copied()
+    .filter(|name| contains_word(&body_joined, name))
+    .collect();
     let mut lines = header_lines;
     if contains_word(&body_joined, "builtins") {
         lines.push("import builtins".to_string());

--- a/src/backends/pyo3/gen_stubs/protocol.rs
+++ b/src/backends/pyo3/gen_stubs/protocol.rs
@@ -1,5 +1,5 @@
 use super::{pyi_docstring, python_safe_name, substitute_capsule_type};
-use crate::backends::pyo3::type_map::python_type;
+use crate::backends::pyo3::type_map::{python_callback_return_type, python_type};
 use crate::codegen::shared::substitute_excluded_types;
 use crate::core::config::TraitBridgeConfig;
 use crate::core::ir::ApiSurface;
@@ -86,8 +86,10 @@ pub(super) fn gen_visitor_protocol_stub(
             };
             params.push(format!("{}: {}", p.name, param_type));
         }
+        // Return position: the host produces this value and the bridge extracts it, so it takes
+        // the widest annotation the extraction accepts. Parameters above stay on `python_type`.
         let return_type = substitute_capsule_type(
-            &python_type(&substitute_excluded_types(&method.return_type, &excluded)),
+            &python_callback_return_type(&substitute_excluded_types(&method.return_type, &excluded)),
             capsule_names,
         );
         let safe_name = python_safe_name(&method.name);

--- a/src/backends/pyo3/type_map.rs
+++ b/src/backends/pyo3/type_map.rs
@@ -81,3 +81,36 @@ pub fn python_type(ty: &TypeRef) -> String {
         TypeRef::Duration => "int".to_string(),
     }
 }
+
+/// Maps a TypeRef to its Python representation for a value the host *returns* to a trait
+/// bridge — a `Protocol` method the caller implements and PyO3 extracts from.
+///
+/// Numeric sequences widen to `Iterable[...]`. PyO3's `Vec<T>` extraction accepts any object
+/// passing `PySequence_Check`, not just `list`, so annotating these as `list[...]` understates
+/// the boundary and forces array-based implementations (NumPy and friends) through a `.tolist()`
+/// the bridge never needed. Parameters keep [`python_type`], which describes what the bridge
+/// actually passes in.
+///
+/// Only numeric leaves widen. `Iterable[str]` would admit a bare `str` — `str` is iterable and
+/// yields `str` — which PyO3 explicitly rejects (`Can't extract \`str\` to \`Vec\``), so widening
+/// a `Vec<String>` return would delete a static check that catches a real mistake. `str` is not
+/// an `Iterable[float]`, so the numeric case has no such hole, and it is the only case with an
+/// array form to accommodate.
+pub fn python_callback_return_type(ty: &TypeRef) -> String {
+    match ty {
+        TypeRef::Vec(inner) if has_numeric_leaf(inner) => {
+            format!("Iterable[{}]", python_callback_return_type(inner))
+        }
+        TypeRef::Optional(inner) => format!("{} | None", python_callback_return_type(inner)),
+        other => python_type(other),
+    }
+}
+
+/// True when `ty` is a numeric scalar, or nests down to one through `Vec`.
+fn has_numeric_leaf(ty: &TypeRef) -> bool {
+    match ty {
+        TypeRef::Primitive(_) => true,
+        TypeRef::Vec(inner) => has_numeric_leaf(inner),
+        _ => false,
+    }
+}

--- a/tests/backends_pyo3_gen_stubs_test.rs
+++ b/tests/backends_pyo3_gen_stubs_test.rs
@@ -2223,3 +2223,94 @@ fn test_pyi_plugin_protocol_types_config_params_as_options_dataclass() {
         "plugin Protocol must type options-dataclass config params as options.X:\n{content}"
     );
 }
+
+#[test]
+fn test_pyi_plugin_protocol_widens_sequence_returns_but_not_params() {
+    let backend = Pyo3Backend;
+    let mut config = make_config_with_stubs();
+    config.trait_bridges = vec![alef::core::config::TraitBridgeConfig {
+        trait_name: "Embedder".to_string(),
+        register_fn: Some("register_embedder".to_string()),
+        registry_getter: Some("test_lib::registry::get".to_string()),
+        super_trait: Some("Plugin".to_string()),
+        bind_via: alef::core::config::BridgeBinding::FunctionParam,
+        ..Default::default()
+    }];
+
+    let embedder = TypeDef {
+        name: "Embedder".to_string(),
+        rust_path: "test_lib::Embedder".to_string(),
+        is_trait: true,
+        is_opaque: true,
+        methods: vec![
+            MethodDef {
+                name: "embed".to_string(),
+                params: vec![ParamDef {
+                    name: "texts".to_string(),
+                    ty: TypeRef::Vec(Box::new(TypeRef::String)),
+                    ..Default::default()
+                }],
+                return_type: TypeRef::Vec(Box::new(TypeRef::Vec(Box::new(TypeRef::Primitive(PrimitiveType::F32))))),
+                receiver: Some(ReceiverKind::Ref),
+                ..Default::default()
+            },
+            MethodDef {
+                name: "scores".to_string(),
+                params: vec![],
+                return_type: TypeRef::Vec(Box::new(TypeRef::Primitive(PrimitiveType::F32))),
+                receiver: Some(ReceiverKind::Ref),
+                ..Default::default()
+            },
+            MethodDef {
+                name: "supported_mime_types".to_string(),
+                params: vec![],
+                return_type: TypeRef::Vec(Box::new(TypeRef::String)),
+                receiver: Some(ReceiverKind::Ref),
+                ..Default::default()
+            },
+            MethodDef {
+                name: "dimensions".to_string(),
+                params: vec![],
+                return_type: TypeRef::Primitive(PrimitiveType::Usize),
+                receiver: Some(ReceiverKind::Ref),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    let api = ApiSurface {
+        crate_name: "test_lib".to_string(),
+        version: "0.1.0".to_string(),
+        types: vec![embedder],
+        ..Default::default()
+    };
+
+    let content = backend.generate_type_stubs(&api, &config).unwrap()[0].content.clone();
+
+    // The bridge extracts this value via PyO3, which accepts any `PySequence` — annotating it
+    // `list[list[float]]` would reject NumPy-array backends the boundary handles fine.
+    assert!(
+        content.contains("def embed(self, texts: list[str]) -> Iterable[Iterable[float]]: ..."),
+        "nested numeric return must widen to Iterable while the param stays list:\n{content}"
+    );
+    assert!(
+        content.contains("def scores(self) -> Iterable[float]: ..."),
+        "flat numeric return must widen to Iterable:\n{content}"
+    );
+    assert!(
+        content.contains("from typing import") && content.contains("Iterable"),
+        "widened return must pull in the Iterable import:\n{content}"
+    );
+    // `str` satisfies `Iterable[str]` but PyO3 rejects it ("Can't extract `str` to `Vec`"), so
+    // widening a string sequence would delete a static check instead of relaxing a false one.
+    assert!(
+        content.contains("def supported_mime_types(self) -> list[str]: ..."),
+        "string sequence return must NOT widen:\n{content}"
+    );
+    // Scalars are unaffected — widening applies only to numeric sequences.
+    assert!(
+        content.contains("def dimensions(self) -> int: ..."),
+        "non-sequence returns must keep their precise type:\n{content}"
+    );
+}


### PR DESCRIPTION
Closes #202.

## Problem

Trait-bridge `Protocol` methods are implemented by the host and extracted by the bridge, but their return types were being mapped with the parameter rule, so `Vec<Vec<f32>>` rendered as `list[list[float]]`.

PyO3's `Vec<T>` extraction accepts any object passing `PySequence_Check` — it never requires a `list`. So the stub rejects values the bridge already handles, and every NumPy-based backend is forced into a `.tolist()` that converts nothing.

## The change

`python_callback_return_type` in `src/backends/pyo3/type_map.rs` renders `TypeRef::Vec` as `Iterable[...]`, used only for the `Protocol` return position in `gen_stubs/protocol.rs`. Parameters and ordinary function stubs keep `python_type` and its precise `list[...]`.

`Iterable` rather than `Sequence`: `np.ndarray` is not a nominal `collections.abc.Sequence`, so both mypy and pyright reject it against `Sequence[Sequence[float]]` and accept it against `Iterable[Iterable[float]]`.

## Numeric leaves only

`Vec<String>` deliberately does not widen. `str` satisfies `Iterable[str]`, but PyO3 rejects it (``Can't extract `str` to `Vec` ``) and the generated bridge turns that into `Default::default()`. Widening string sequences would delete a static check rather than relax a false one — a `DocumentExtractor` returning a bare `"application/pdf"` would type-check clean, register with an empty MIME list, and match nothing.

`str` is not an `Iterable[float]`, so the numeric case has no equivalent hole, and numeric sequences are the only ones with an array form to accommodate.

## Effect on kreuzberg

Regenerating `packages/python/xberg/_xberg.pyi`:

```diff
-from typing import Any, Literal, Protocol, TypedDict
+from typing import Any, Iterable, Literal, Protocol, TypedDict

 class EmbeddingBackend(Protocol):
-    def embed(self, texts: list[str]) -> list[list[float]]: ...
+    def embed(self, texts: list[str]) -> Iterable[Iterable[float]]: ...

 class RerankerBackend(Protocol):
-    def rerank(self, query: str, documents: list[str]) -> list[float]: ...
+    def rerank(self, query: str, documents: list[str]) -> Iterable[float]: ...
```

`DocumentExtractor.supported_mime_types` correctly stays `list[str]`.

## Verification

Built a kreuzberg wheel at rc.40 and drove the plugin path end to end — `register_embedding_backend`, then `extract()` with semantic chunking against `{"type": "plugin"}` — asserting the vectors landing on the chunks are the ones the backend returned. The compiled extension is identical before and after; only the `.pyi` changes.

| Backend returns | Runtime | Before | After |
|---|---|---|---|
| `list[list[float]]` | exact vectors | pass | pass |
| `np.ndarray` 2-D float32 | exact vectors | reject | pass |
| `list[np.ndarray]` 1-D float32 | exact vectors | reject | pass |
| `np.ndarray` 2-D float64 | exact vectors | reject | pass |
| bare `str` from `supported_mime_types` | rejected by PyO3 | reject | reject |

Checked with both mypy and pyright.

| Check | Result |
|---|---|
| `cargo clippy --all-targets --all-features -- -D warnings` | rc=0 |
| `cargo fmt --check` | rc=0 |
| `cargo test --workspace` | 4314 passed, 2 pre-existing failures |

The two failures are `scaffold::tests::ffi_go_java_ruby::test_scaffold_ffi_with_core_import` and `test_scaffold_java_production_features`; both fail identically on clean `origin/main`.

## Known imprecision

`Iterable` still admits generators, which `PySequence_Check` rejects. Returning a generator from a plugin callback isn't a real use case, and closing it properly needs an annotation that admits `ndarray` but not generators, which Python's type system doesn't express. Disclosed rather than designed for.

Separately, the generated docs reference renders these signatures through `src/docs/type_mapping.rs` — a different type map shared by all 16 languages — so `api-python.md` still says `list[list[float]]`. Widening it there would be wrong for the JSON-marshalled bindings, where `list` genuinely is required.
